### PR TITLE
Va3 35 fetch organisation info from remote server

### DIFF
--- a/va-common/spec/oph/common/organisation_service_spec.clj
+++ b/va-common/spec/oph/common/organisation_service_spec.clj
@@ -1,0 +1,66 @@
+(ns oph.common.organisation-service-spec
+  (:require [speclj.core :refer :all]
+            [oph.common.organisation-service :as o]))
+
+(def
+  contact-collection
+  [{:kieli "kieli_sv#1" :email "turun.kaupunki@turku.fi" }
+  {:kieli "kieli_fi#1" :email "turun.kaupunki@turku.fi" }
+  {:kieli "kieli_fi#1" :osoite "PL 355" :postinumeroUri "posti_20101"}
+  {:kieli "kieli_fi#1" :www "http://www.turku.fi"}
+  {:kieli "kieli_fi#1" :numero "02  262 7229" :tyyppi "puhelin"}
+  {:kieli "kieli_fi#1" :numero "02-330 000" :tyyppi "faksi"}
+  {:postitoimipaikka "ÅBO" :kieli "kieli_sv#1"}
+  {:kieli "kieli_sv#1" :osoite "PL 355" :postinumeroUri "posti_20101"}
+  {:kieli "kieli_sv#1" :www "http://www.turku.fi"}
+  {:kieli "kieli_sv#1" :numero "02-330 000", :tyyppi "puhelin"}
+  {:postitoimipaikka "TURKU" :kieli "kieli_fi#1" :osoite "PL 355"}])
+
+(def organisation
+  {:nimi {:fi "Turun kaupunki" :sv "Åbo stad"}
+   :ytunnus "0204819-8"
+   :tyypit ["Koulutustoimija"]
+   :yhteystiedot contact-collection})
+
+(describe
+  "Filter translations"
+  (it "filters translations in collection"
+    (let [filtered (o/filter-translations :sv contact-collection)]
+      (should-not (empty? filtered))
+      (should= 5 (count filtered))
+      (should= "ÅBO" (:postitoimipaikka (second filtered ))))
+    (let [filtered (o/filter-translations :fi contact-collection)]
+      (should-not (empty? filtered))
+      (should= 6 (count filtered))
+      (should= "TURKU" (:postitoimipaikka (last filtered ))))
+    (let [filtered (o/filter-translations :en contact-collection)]
+      (should (empty? filtered)))))
+
+(describe
+  "Compact address data"
+  (it
+    "compacts translated address data"
+    (let [compacted
+          (o/compact-address
+            (into {} (o/filter-translations :fi contact-collection)))]
+      (should-not (empty? compacted))
+      (should= 3 (count compacted))
+      (should= "TURKU" (:city compacted)))))
+
+(describe
+  "Compact organisation info"
+  (it
+    "compacts organisation info"
+    (let [compacted (o/compact-organisation-info :fi organisation)]
+      (should-not (empty? compacted))
+      (should= 5 (count compacted))
+      (should= "turun.kaupunki@turku.fi" (:email compacted))
+      (should= "0204819-8" (:organisation-id compacted))
+      (should= "Turun kaupunki" (:name compacted))
+      (should-not (empty? (:contact compacted)))
+      (should= 3 (count (:contact compacted)))
+      (should= "TURKU" (get-in compacted [:contact :city]))
+      (should= "PL 355" (get-in compacted [:contact :address]))
+      (should= "20101" (get-in compacted [:contact :postal-number])))))
+
+(run-specs)

--- a/va-common/src/oph/common/organisation_service.clj
+++ b/va-common/src/oph/common/organisation_service.clj
@@ -17,9 +17,7 @@
 (defn- json->map [body] (cheshire/parse-string body true))
 
 (defn find-by-id
-  "Fetch organisation data by organisation id (Y-tunnus in Finnish).
-  If server returns anything that OK (HTTP 200) exception will be thrown.
-  Note: Compojure API should catch that exception and return appropriate error."
+  "Fetch organisation data by organisation id (Y-tunnus in Finnish)."
   [organisation-id]
   (let [url
         (str service-url "organisaatio/" organisation-id "?includeImage=false")
@@ -71,7 +69,10 @@
   Function assumes name and contact info are translated.
 
   Data will be in form of
-  {:name :email :organisation-id :county}" 
+  {:name :email :organisation-id :county}
+
+  If remote server returns error (status anything else than HTTP OK/200)
+  exception will be handled. Compojure API should handle this exception."
   ([id lang]
    (compact-organisation-info lang (find-by-id id)))
   ([id]

--- a/va-common/src/oph/common/organisation_service.clj
+++ b/va-common/src/oph/common/organisation_service.clj
@@ -19,7 +19,8 @@
 (defn find-by-id
   "Fetch organisation data by organisation id (Y-tunnus in Finnish)."
   [organisation-id]
-  (let [url (str service-url "organisaatio/" organisation-id "?includeImage=false")]
+  (let [url
+        (str service-url "organisaatio/" organisation-id "?includeImage=false")]
     (json->map (:body @(http/get url)))))
 
 (defn compact-address

--- a/va-common/src/oph/common/organisation_service.clj
+++ b/va-common/src/oph/common/organisation_service.clj
@@ -1,0 +1,59 @@
+(ns oph.common.organisation-service
+  (:require [org.httpkit.client :as http]
+            [cheshire.core :as cheshire]))
+
+(def service-url "https://virkailija.opintopolku.fi/organisaatio-service/rest/")
+
+(def languages {:fi "kieli_fi#1" :sv "kieli_sv#1" :en "kieli_en#1" })
+
+(def compact-contact-fields #{ :osoite :postinumeroUri :postitoimipaikka })
+
+(defn filter-translations
+  "Filter vector collection of values by translation.
+  Collections of 'organisaatio-service' has :kieli key defining translation."
+  [lang col]
+    (not-empty (filter #(= (:kieli %) (lang languages)) col)))
+
+(defn- json->map [body] (cheshire/parse-string body true))
+
+(defn find-by-id
+  "Fetch organisation data by organisation id (Y-tunnus in Finnish)."
+  [organisation-id]
+  (let [url (str service-url "organisaatio/" organisation-id "?includeImage=false")]
+    (json->map (:body @(http/get url)))))
+
+(defn compact-address
+  "Convert full address info to compact one:
+  {:address :postal-number :city}
+  Postal addess is being trimmed by removing Finnish tag 'posti_'."
+  [address]
+  (let [{:keys [osoite postinumeroUri postitoimipaikka]} address]
+    {:address osoite
+     :postal-number (clojure.string/replace postinumeroUri "posti_" "")
+     :city postitoimipaikka}))
+
+(defn get-compact-translated-info
+  "Get (find) organisation with given organisation id (Y-tunnus in Finnish)
+  and compact info to contain only necessary data. Data will be in following:
+  {:name, :email, :organisation-id, :contact {:address, :postal-number, :city},
+  :county}.
+  
+  You can also give language. If data is found in given language, translated
+  info will be returned. Otherwise it will be in Finnish.
+  
+  Language can be {:fi, :sv, :en}
+  
+  Function assumes name and contact info are translated."
+  ([id lang]
+  (let [{:keys [nimi yhteystiedot ytunnus]} (find-by-id id)
+        translated-contact
+        (into {} (or
+                   (filter-translations lang yhteystiedot)
+                   (filter-translations :fi yhteystiedot)))]
+    {:name (or (lang nimi) (:fi nimi))
+     :email (:email translated-contact) 
+     :organisation-id ytunnus
+     :contact (compact-address translated-contact)
+     :county nil}))
+  ([id]
+   (get-compact-translated-info id :fi)))

--- a/va-common/src/oph/common/organisation_service.clj
+++ b/va-common/src/oph/common/organisation_service.clj
@@ -31,28 +31,39 @@
      :postal-number (clojure.string/replace postinumeroUri "posti_" "")
      :city postitoimipaikka})
 
+(defn compact-organisation-info
+  "Function compacts organisation info.
+  Values are being filtered by given language and unused values are being
+  filtered out.
+  Output will be
+  {:name :email :organisation-id :county})"
+  [lang {:keys [nimi yhteystiedot ytunnus]}]
+  (let [translated-contact
+        (into {} (or
+                   (filter-translations lang yhteystiedot)
+                   (filter-translations :fi yhteystiedot)))]
+    {:name (or (lang nimi) (:fi nimi))
+     :email (:email translated-contact)
+     :organisation-id ytunnus
+     :contact (compact-address translated-contact)
+     :county nil}))
+
 (defn get-compact-translated-info
   "Get (find) organisation with given organisation id (Y-tunnus in Finnish)
   and compact info to contain only necessary data. Data will be in following:
   {:name, :email, :organisation-id, :contact {:address, :postal-number, :city},
   :county}.
-  
+
   You can also give language. If data is found in given language, translated
   info will be returned. Otherwise it will be in Finnish.
-  
+
   Language can be {:fi, :sv, :en}
-  
-  Function assumes name and contact info are translated."
+
+  Function assumes name and contact info are translated.
+
+  Data will be in form of
+  {:name :email :organisation-id :county}" 
   ([id lang]
-  (let [{:keys [nimi yhteystiedot ytunnus]} (find-by-id id)
-        translated-contact
-        (into {} (or
-                   (filter-translations lang yhteystiedot)
-                   (filter-translations :fi yhteystiedot)))]
-    {:name (or (lang nimi) (:fi nimi))
-     :email (:email translated-contact) 
-     :organisation-id ytunnus
-     :contact (compact-address translated-contact)
-     :county nil}))
+   (compact-organisation-info lang (find-by-id id)))
   ([id]
    (get-compact-translated-info id :fi)))

--- a/va-common/src/oph/common/organisation_service.clj
+++ b/va-common/src/oph/common/organisation_service.clj
@@ -26,11 +26,10 @@
   "Convert full address info to compact one:
   {:address :postal-number :city}
   Postal addess is being trimmed by removing Finnish tag 'posti_'."
-  [address]
-  (let [{:keys [osoite postinumeroUri postitoimipaikka]} address]
-    {:address osoite
+  [{:keys [osoite postinumeroUri postitoimipaikka]}]
+  {:address osoite
      :postal-number (clojure.string/replace postinumeroUri "posti_" "")
-     :city postitoimipaikka}))
+     :city postitoimipaikka})
 
 (defn get-compact-translated-info
   "Get (find) organisation with given organisation id (Y-tunnus in Finnish)


### PR DESCRIPTION
Set of functions for getting organisation info from `organisaatio-service`.

There is tests for functions which filters and compacts data.

You can test function in repl:

```
user=> (use 'oph.common.organisation-service)
nil
user=> (get-compact-translated-info "0245894-7" :fi)
{:name "Jyväskylän yliopisto", :email "kirjaamo@jyu.fi", :organisation-id "0245894-7", :contact {:address "PL 35", :postal-number "40014", :city "JYVÄSKYLÄN YLIOPISTO"}, :county nil}
user=> (get-compact-translated-info "0204819-8" :sv)
{:name "Åbo stad", :email "turun.kaupunki@turku.fi", :organisation-id "0204819-8", :contact {:address "PL 355", :postal-number "20101", :city "ÅBO"}, :county nil}
```

https://virkailija.opintopolku.fi/organisaatio-service/swagger/index.html#!/organisaatio/getOrganisaatioByOID

https://confluence.csc.fi/display/OPHPALV/Organisaatiopalvelun+tekninen+dokumentaatio