### PR TITLE
Va3 47 modify growing field set

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "no-trailing-spaces": "error",
     "quotes": ["error", "double"],
     "indent": ["error", 2, {"SwitchCase": 1}],
-    "curly": "error"
+    "curly": "error",
+    "react/prop-types": [2, {"skipUndeclared": true}]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parserOptions": {
     "ecmaVersion": 5,
     "sourceType": "module",

--- a/soresu-form/web/form/edit/EditComponent.jsx
+++ b/soresu-form/web/form/edit/EditComponent.jsx
@@ -129,7 +129,8 @@ export class EditComponent extends React.Component {
       t => hiddenFields.indexOf(t) === -1)
 
     const addElementButtons = addableFields.map((key, i) => (
-      <a href="#" key={i} className="soresu-edit" onClick={this.handleOnAddClick.bind(this, key)}>
+      <a href="#" key={i} className="soresu-edit"
+        onClick={this.handleOnAddClick.bind(this, key)}>
         {EditComponent.fieldTypeInFI(key)}
       </a>
     ))

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -30,26 +30,61 @@ export default class FormEdit extends React.Component {
         koodistosLoader={state.koodistosLoader}/>
   }
 
-  static renderField(controller, formEditorController, state, infoElementValues, field, renderingParameters) {
+  static renderField(controller, formEditorController, state,
+    infoElementValues, field, renderingParameters) {
+
     const fields = state.form.content
     const htmlId = controller.constructHtmlId(fields, field.id)
-    const fieldProperties = { fieldType: field.fieldType, lang: state.configuration.lang, key: htmlId, htmlId: htmlId, field: field }
+    const fieldProperties = {
+      fieldType: field.fieldType, lang: state.configuration.lang, key: htmlId,
+      htmlId: htmlId, field: field }
+
     if(FormEditComponent.fieldTypeMapping()[field.fieldType]) {
-      return FormEdit.createFormEditComponent(controller, formEditorController, state, field, fieldProperties, renderingParameters)
+      return FormEdit.createFormEditComponent(controller, formEditorController,
+        state, field, fieldProperties, renderingParameters)
     } else if (field.fieldClass == "infoElement") {
-      const previewInfoElement =  FormPreview.createInfoComponent(state, infoElementValues, field, fieldProperties, false)
-      return <InfoElementEditWrapper formEditorController={formEditorController} wrappedElement={previewInfoElement} htmlId={htmlId} key={htmlId} field={field}/>
+      const previewInfoElement =  FormPreview.createInfoComponent(state,
+        infoElementValues, field, fieldProperties, false)
+      return (
+        <InfoElementEditWrapper
+          formEditorController={formEditorController}
+          wrappedElement={previewInfoElement} htmlId={htmlId} key={htmlId}
+          field={field} />
+      )
     } else if (field.fieldClass == "wrapperElement") {
-      if(controller.getCustomPreviewComponentTypeMapping()[field.fieldType] || field.fieldType === "growingFieldset") {
-        const previewWrapperElement = FormPreview.createWrapperComponent(FormPreview.renderField, controller, formEditorController, state, infoElementValues, field, fieldProperties, renderingParameters)
-        return <BasicEditWrapper formEditorController={formEditorController} wrappedElement={previewWrapperElement} htmlId={htmlId} key={htmlId} field={field}/>
+      if(controller.getCustomPreviewComponentTypeMapping()[field.fieldType] ||
+        field.fieldType === "growingFieldset") {
+
+        const previewWrapperElement = FormPreview.createWrapperComponent(
+          FormPreview.renderField, controller, formEditorController, state,
+          infoElementValues, field, fieldProperties, renderingParameters)
+
+        return (
+          <BasicEditWrapper
+            formEditorController={formEditorController}
+            wrappedElement={previewWrapperElement}
+            htmlId={htmlId} key={htmlId} field={field} />
+        )
       }
       else {
-        const editableWrapperElement = FormPreview.createWrapperComponent(FormEdit.renderField, controller, formEditorController, state, infoElementValues, field, fieldProperties, renderingParameters)
-        return <AppendableEditWrapper formEditorController={formEditorController} wrappedElement={editableWrapperElement} htmlId={htmlId} key={htmlId} field={field}/>
+        const editableWrapperElement = FormPreview.createWrapperComponent(
+          FormEdit.renderField, controller, formEditorController, state,
+          infoElementValues, field, fieldProperties, renderingParameters)
+
+        return (
+          <AppendableEditWrapper
+            formEditorController={formEditorController}
+            wrappedElement={editableWrapperElement}
+            htmlId={htmlId} key={htmlId} field={field} />
+        )
       }
     }
-    return <BasicFieldEdit formEditorController={formEditorController} htmlId={fieldProperties.htmlId} key={fieldProperties.htmlId} field={field}/>
+    return (
+      <BasicFieldEdit
+        formEditorController={formEditorController}
+        htmlId={fieldProperties.htmlId}
+        key={fieldProperties.htmlId} field={field} />
+    )
   }
 
   render() {

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -19,15 +19,15 @@ export default class FormEdit extends React.Component {
   static createFormEditComponent(controller, formEditorController, state, field, fieldProperties, renderingParameters) {
     const translations = state.configuration.translations
     return <FormEditComponent {...fieldProperties}
-        renderingParameters={renderingParameters}
-        translations={translations}
-        controller={controller}
-        formEditorController={formEditorController}
-        customProps={controller.getCustomComponentProperties(state)}
-        attachment={state.saveStatus.attachments[field.id]}
-        attachmentDownloadUrl={controller.createAttachmentDownloadUrl(state, field) }
-        koodistos={state.koodistos}
-        koodistosLoader={state.koodistosLoader}/>
+      renderingParameters={renderingParameters}
+      translations={translations}
+      controller={controller}
+      formEditorController={formEditorController}
+      customProps={controller.getCustomComponentProperties(state)}
+      attachment={state.saveStatus.attachments[field.id]}
+      attachmentDownloadUrl={controller.createAttachmentDownloadUrl(state, field) }
+      koodistos={state.koodistos}
+      koodistosLoader={state.koodistosLoader}/>
   }
 
   static renderField(controller, formEditorController, state,

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -98,11 +98,14 @@ export default class FormEdit extends React.Component {
     const readOnlyNotificationText = formEditorController.readOnlyNotificationText ? formEditorController.readOnlyNotificationText : "Ei muokkausoikeutta"
     const readOnlyNotification = formEditorController.allowEditing ? null : <div className="soresu-read-only-notification">{readOnlyNotificationText}</div>
 
-    return  <div className="soresu-form-edit soresu-edit">
-      {readOnlyNotification}
-      <CSSTransitionGroup transitionName="soresu-dynamic-children-transition">
-        {fields.map(renderField)}
-      </CSSTransitionGroup>
-    </div>
+    return (
+      <div className="soresu-form-edit soresu-edit">
+        {readOnlyNotification}
+        <CSSTransitionGroup
+          transitionName="soresu-dynamic-children-transition">
+          {fields.map(renderField)}
+        </CSSTransitionGroup>
+      </div>
+    )
   }
 }

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -52,8 +52,7 @@ export default class FormEdit extends React.Component {
           field={field} />
       )
     } else if (field.fieldClass == "wrapperElement") {
-      if(controller.getCustomPreviewComponentTypeMapping()[field.fieldType] ||
-        field.fieldType === "growingFieldset") {
+      if(controller.getCustomPreviewComponentTypeMapping()[field.fieldType]) {
 
         const previewWrapperElement = FormPreview.createWrapperComponent(
           FormPreview.renderField, controller, formEditorController, state,

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -1,18 +1,18 @@
-import React from 'react'
-import _ from 'lodash'
+import React from "react"
+import _ from "lodash"
 
-import styles from '../style/preview.less'
+import styles from "../style/preview.less"
 
 import {
   BasicFieldEdit,
   BasicEditWrapper,
   AppendableEditWrapper,
   InfoElementEditWrapper
-} from './EditComponent.jsx'
-import CSSTransitionGroup from '../component/wrapper/CSSTransitionGroup.jsx'
-import FormEditComponent from './FormEditComponent'
+} from "./EditComponent.jsx"
+import CSSTransitionGroup from "../component/wrapper/CSSTransitionGroup.jsx"
+import FormEditComponent from "./FormEditComponent"
 
-import FormPreview from '../FormPreview.jsx'
+import FormPreview from "../FormPreview.jsx"
 
 export default class FormEdit extends React.Component {
 

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -13,7 +13,9 @@ import FormPreview from "../FormPreview.jsx"
 
 export default class FormEdit extends React.Component {
 
-  static createFormEditComponent(controller, formEditorController, state, field, fieldProperties, renderingParameters) {
+  static createFormEditComponent(controller, formEditorController, state,
+    field, fieldProperties, renderingParameters) {
+
     const translations = state.configuration.translations
     return <FormEditComponent {...fieldProperties}
       renderingParameters={renderingParameters}
@@ -22,9 +24,10 @@ export default class FormEdit extends React.Component {
       formEditorController={formEditorController}
       customProps={controller.getCustomComponentProperties(state)}
       attachment={state.saveStatus.attachments[field.id]}
-      attachmentDownloadUrl={controller.createAttachmentDownloadUrl(state, field) }
+      attachmentDownloadUrl={controller.createAttachmentDownloadUrl(
+        state, field) }
       koodistos={state.koodistos}
-      koodistosLoader={state.koodistosLoader}/>
+      koodistosLoader={state.koodistosLoader} />
   }
 
   static renderField(controller, formEditorController, state,
@@ -92,11 +95,20 @@ export default class FormEdit extends React.Component {
     const fields = state.form.content
 
     const renderField = function(field) {
-      return FormEdit.renderField(controller, formEditorController, state, infoElementValues, field)
+      return FormEdit.renderField(
+        controller, formEditorController, state, infoElementValues, field)
     }
 
-    const readOnlyNotificationText = formEditorController.readOnlyNotificationText ? formEditorController.readOnlyNotificationText : "Ei muokkausoikeutta"
-    const readOnlyNotification = formEditorController.allowEditing ? null : <div className="soresu-read-only-notification">{readOnlyNotificationText}</div>
+    const readOnlyNotificationText =
+      formEditorController.readOnlyNotificationText ?
+        formEditorController.readOnlyNotificationText : "Ei muokkausoikeutta"
+
+    const readOnlyNotification = formEditorController.allowEditing ?
+      null : (
+        <div className="soresu-read-only-notification">
+          {readOnlyNotificationText}
+        </div>
+      )
 
     return (
       <div className="soresu-form-edit soresu-edit">

--- a/soresu-form/web/form/edit/FormEdit.jsx
+++ b/soresu-form/web/form/edit/FormEdit.jsx
@@ -1,7 +1,4 @@
 import React from "react"
-import _ from "lodash"
-
-import styles from "../style/preview.less"
 
 import {
   BasicFieldEdit,

--- a/soresu-form/web/form/edit/FormEditController.js
+++ b/soresu-form/web/form/edit/FormEditController.js
@@ -198,7 +198,7 @@ export default class FormEditorController {
         parentField.fieldType === "growingFieldsetChild" ?
         this.generateUniqueId(
           `${parentField.id}.${newFieldType}`, 0, "_") :
-          this.generateUniqueId(newFieldType, 0)
+        this.generateUniqueId(newFieldType, 0)
       const newChild = this.createNewField(newFieldType, newId)
 
       const parent = parentField ? FormUtil.findField(formDraftJson.content, parentField.id) : formDraftJson.content

--- a/soresu-form/web/form/edit/FormEditController.js
+++ b/soresu-form/web/form/edit/FormEditController.js
@@ -111,7 +111,8 @@ export default class FormEditorController {
       case "growingFieldsetChild":
         return {
           children: [
-            this.createNewField("textField", `${id}.textField`)
+            this.createNewField("textField",
+              this.generateUniqueId(`${id}.textField`, 0, "_"))
           ]
         }
       case "growingFieldset":
@@ -172,15 +173,18 @@ export default class FormEditorController {
     return newField
   }
 
-  generateUniqueId(fieldType, index) {
-    const proposed = `${fieldType}-${index}`
-    if (_.isEmpty(JsUtil.flatFilter(
-      this.formDraftJson.content, n => n.id === proposed))) {
-      return proposed
-    }
-    return this.generateUniqueId(fieldType, index + 1)
+  findElementsById(id) {
+    return JsUtil.flatFilter(
+      this.formDraftJson.content, n => n.id === id)
   }
 
+  generateUniqueId(baseId, index, delimiter = "-") {
+    const proposed = `${baseId}${delimiter}${index}`
+    if (_.isEmpty(this.findElementsById(proposed))) {
+      return proposed
+    }
+    return this.generateUniqueId(baseId, index + 1, delimiter)
+  }
 
   addChildFieldAfter(fieldToAddAfter, newFieldType) {
     this.doEdit(() => {
@@ -190,7 +194,11 @@ export default class FormEditorController {
       const fieldToAddAfterOnForm = FormUtil.findField(formDraftJson.content, fieldToAddAfter.id)
       const indexOfNewChild = childArray.indexOf(fieldToAddAfterOnForm) + 1
 
-      const newId = this.generateUniqueId(newFieldType, 0)
+      const newId = parentField &&
+        parentField.fieldType === "growingFieldsetChild" ?
+        this.generateUniqueId(
+          `${parentField.id}.${newFieldType}`, 0, "_") :
+          this.generateUniqueId(newFieldType, 0)
       const newChild = this.createNewField(newFieldType, newId)
 
       const parent = parentField ? FormUtil.findField(formDraftJson.content, parentField.id) : formDraftJson.content

--- a/soresu-form/web/form/style/formedit.less
+++ b/soresu-form/web/form/style/formedit.less
@@ -96,6 +96,10 @@ div.soresu-field-edit {
   }
 }
 
+.soresu-edit ol {
+  list-style-type: none;
+}
+
 .soresu-field-content {
   padding-left: 10px;
   padding-right: 10px;


### PR DESCRIPTION
Enable editing growing fieldset children fields.

This logic is pretty much starting from `FormEditController.js:113`. Rest are just refactoring and cleaning code.

Note that now you can also add many other fields than just textfields to growing fieldset.