### PR TITLE
changed the way BusinessIdSearch is set to be rendered

### DIFF
--- a/soresu-form/web/form/FormContainer.jsx
+++ b/soresu-form/web/form/FormContainer.jsx
@@ -32,19 +32,13 @@ export default class FormContainer extends React.Component {
 
     const isTestProfile = this.props.state.configuration.develMode
     const isPreviewPage = this.props.state.saveStatus.savedObject === null
-    const isAdminViewPage = this.props.state.configuration.preview === true
-    const isRefreshed = performance.navigation.type == 1
-    const isValiselvitys = this.props.hakemusType == "valiselvitys"
-    const isLoppuselvitys = this.props.hakemusType == "loppuselvitys"
 
-    const conditions = !isTestProfile && !isAdminViewPage && !isValiselvitys && !isLoppuselvitys && (!isPreviewPage && ((this.props.state.saveStatus.savedObject.version == 1) || (isRefreshed && ( ["organization", "organization-email", "business-id", "organization-postal-address"].map((item) => this.getOrganizationValues(item)).some(x => (x == "" || x == null))))))
-
-
+    const isBusinessIdSearchNeeded = this.props.showBusinessIdSearch && !isTestProfile && !isPreviewPage && ( ["organization", "organization-email", "business-id", "organization-postal-address"].map((item) => this.getOrganizationValues(item)).some(x => (x == "" || x == null)))
 
     return (
       <section id={containerId} >
         {headerElements}
-        { (conditions) &&
+        { (isBusinessIdSearchNeeded) &&
           <BusinessIdSearch state={this.props.state} controller={controller}/> }
         {formElement}
       </section>

--- a/va-hakija/web/va/SelvitysApp.jsx
+++ b/va-hakija/web/va/SelvitysApp.jsx
@@ -172,7 +172,7 @@ function initFormController() {
   const initialValues = {language: VaUrlCreator.chooseInitialLanguage(urlContent)}
   const stateProperty = controller.initialize(formOperations, initialValues, urlContent)
   return { stateProperty: stateProperty, getReactComponent: function(state) {
-    return <VaForm controller={controller} state={state} hakemusType={selvitysType}/>
+    return <VaForm controller={controller} state={state} hakemusType={selvitysType} showBusinessIdSearch={false}/>
   }}
 }
 

--- a/va-hakija/web/va/VaApp.jsx
+++ b/va-hakija/web/va/VaApp.jsx
@@ -119,7 +119,7 @@ function initVaFormController() {
   const initialValues = {language: VaUrlCreator.chooseInitialLanguage(urlContent)}
   const stateProperty = controller.initialize(formOperations, initialValues, urlContent)
   return { stateProperty: stateProperty, getReactComponent: function(state) {
-    return <VaForm controller={controller} state={state} hakemusType="hakemus"/>
+    return <VaForm showBusinessIdSearch={true} controller={controller} state={state} hakemusType="hakemus"/>
   }}
 }
 

--- a/va-hakija/web/va/VaForm.jsx
+++ b/va-hakija/web/va/VaForm.jsx
@@ -28,6 +28,7 @@ export default class VaForm extends React.Component {
                                             lang={state.configuration.lang} />
     const headerElements = [registerNumberDisplay, changeRequest]
     const formContainerClass = state.configuration.preview ? FormPreview : Form
+    const show = this.props.showBusinessIdSearch && this.props.hakemusType == "hakemus"
     return(
       <div>
         <VaOldBrowserWarning lang={state.configuration.lang}
@@ -44,6 +45,7 @@ export default class VaForm extends React.Component {
                        headerElements={headerElements}
                        infoElementValues={state.avustushaku}
                        hakemusType = {this.props.hakemusType}
+                       showBusinessIdSearch = {this.props.showBusinessIdSearch}
         />
       </div>
     )


### PR DESCRIPTION
Changed such that the FormContainer -component has a prop stating whether to show BusinessIdsearch or not. 

Instructions for testing 
1. go to frontpage of an application (such as http://localhost:8080/avustushaku/6/ or whatever you have active in your local installation) and check the preview-site (e.g. http://localhost:8080/avustushaku/6/nayta?avustushaku=6&hakemus=&lang=fi) and observe that no BusinessIdSearch Modal is shown
2. go to hakemus-page, start filling out the form, see BusinessIdSearch Modal appear
3. fill in the businessId, e.g. 0204819-8, see that fields are filled accordingly
4. go to virkalija-site (admin editor), observe that no BusinessIdSearch is shown
5.  go to "väliselvitys" and "loppuselvitys" -site, observe that no BusinessIdSearch is shown