### PR TITLE
Va3 75 support for new admin ui

### DIFF
--- a/va-virkailija/config/dev.edn
+++ b/va-virkailija/config/dev.edn
@@ -2,7 +2,8 @@
           :url {:fi "http://localhost:8080/"
                 :sv "http://localhost:8080/"}
           :enable-access-log? false
-          :require-https? false}
+          :require-https? false
+          :local-front-url "http://localhost:3449"}
  :api {:restricted-routes? false}
  :virkailija-db {:database-name "va-dev"}
  :form-db {:database-name "va-dev"}

--- a/va-virkailija/src/oph/va/virkailija/server.clj
+++ b/va-virkailija/src/oph/va/virkailija/server.clj
@@ -75,6 +75,13 @@
              :handler authenticated-access
              :on-error redirect-to-login}])
 
+(defn wrap-with-local-cors [handler url]
+  (fn [request]
+    (let [response (handler request)]
+      (-> response
+          (assoc-in [:headers "Access-Control-Allow-Origin"] url)
+          (assoc-in [:headers "Access-Control-Allow-Credentials"] true)))))
+
 (defn- with-authentication [site]
   (-> site
       (wrap-authentication backend)
@@ -98,6 +105,9 @@
                   (server/wrap-logger h)
                   (server/wrap-cache-control h)
                   (wrap-not-modified h)
+                  (if-let [local-url (get-in config [:server :local-front-url])]
+                    (wrap-with-local-cors h local-url)
+                    h)
                   (if auto-reload?
                     (wrap-reload h)
                     h))


### PR DESCRIPTION
Lisätään mahdollisuus lokaaliin käyttöliittymän kehitykseen.

Jos configissa on `:local-front-url` arvo, sallitaan tästä osoitteesta pyynnöt.

Dev-configiin lisätty figwheelin käyttämä oletusportti.