### PR TITLE
Va3 95 add migration for payment fields

### DIFF
--- a/va-common/src/oph/va/schema.clj
+++ b/va-common/src/oph/va/schema.clj
@@ -32,9 +32,9 @@
                                  :duration Duration
                                  :focus-areas LocalizedStringList
                                  :selection-criteria LocalizedStringList
-                                 (s/optional-key :operational-unit) s/Str
-                                 (s/optional-key :project) s/Str
-                                 (s/optional-key :operation) s/Str
+                                 :operational-unit s/Str
+                                 :project s/Str
+                                 :operation s/Str
                                  (s/optional-key :rahoitusalueet) [Rahoitusalue]
                                  (s/optional-key :multiplemaksuera) s/Bool
                                  :self-financing-percentage (s/conditional is-percentage? s/Num)})

--- a/va-hakija/src/oph/va/hakija/db/migrations.clj
+++ b/va-hakija/src/oph/va/hakija/db/migrations.clj
@@ -157,3 +157,22 @@
                       update-hakemus-selvitys-email-by-id!
                       {:id             (:id hakemus)
                        :selvitys_email (convert-selvitys-email (:selvitys_email hakemus))}))))
+(defn assoc-in-if [m ks value]
+  (if (nil? (get-in m ks))
+    (assoc-in m ks value)
+    m))
+
+(defn set-missing-content-values [grant]
+  (-> grant
+      (assoc-in-if [:content :operational-unit] "")
+      (assoc-in-if [:content :project] "")
+      (assoc-in-if [:content :operation] "")))
+
+(migrations/defmigration migrate-add-default-values-for-payment-fields "1.47"
+  "Add default values for payment fields `operational-unit`, `project`,
+  `operation`. Default value will be empty string."
+  (doseq [avustushaku (va-db/list-avustushaut)]
+    (common-db/exec
+      :form-db
+      update-avustushaku-content!
+      (set-missing-content-values avustushaku))))

--- a/va-virkailija/src/oph/va/hakija/api.clj
+++ b/va-virkailija/src/oph/va/hakija/api.clj
@@ -73,20 +73,8 @@
          (map avustushaku-response-content)
          first)))
 
-(defn assoc-in-if [m ks value]
-  (if (nil? (get-in m ks))
-    (assoc-in m ks value)
-    m))
-
-(defn set-missing-content-values [grant]
-  (-> grant
-      (assoc-in-if [:content :operational-unit] "")
-      (assoc-in-if [:content :project] "")
-      (assoc-in-if [:content :operation] "")))
-
 (defn get-avustushaku [id]
-  (set-missing-content-values
-    (first (exec :form-db hakija-queries/get-avustushaku {:id id}))))
+  (first (exec :form-db hakija-queries/get-avustushaku {:id id})))
 
 (defn- map-status-list [statuses]
   (map (fn [status] (new HakuStatus status)) statuses))
@@ -95,16 +83,12 @@
   (first (exec :form-db hakija-queries/get-avustushaku-by-status {:id avustushaku-id :statuses (map-status-list statuses)})))
 
 (defn list-avustushaut []
-  (map #(-> %
-            (avustushaku-response-content)
-            (set-missing-content-values))
+  (map avustushaku-response-content
        (exec :form-db hakija-queries/list-avustushaut-not-deleted {})))
 
 (defn list-avustushaut-by-status [statuses]
   (if statuses
-    (map #(-> %
-              (avustushaku-response-content)
-              (set-missing-content-values))
+    (map avustushaku-response-content
          (exec :form-db hakija-queries/list-avustushaut-by-status
                {:statuses (map-status-list statuses)}))
     (list-avustushaut)))


### PR DESCRIPTION
Siirretään maksatuksen kenttien oletusarvojen asetus migraatioihin.