### PR TITLE
Va3 126 payment invoice xml creation

### DIFF
--- a/va-virkailija/src/clojure/oph/va/virkailija/invoice.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/invoice.clj
@@ -1,10 +1,56 @@
 (ns oph.va.virkailija.invoice
-  (:require [clojure.data.xml :refer [element emit emit-str parse]]))
+  (:require [clojure.data.xml :refer [emit emit-str parse
+                                      sexp-as-element]]))
 
-(defn invoice-to-xml [invoice]
-  "Creates xml document (tags) of given invoice of Valtionavustukset maksatus.
+(defn- get-answer-value [answers key]
+  (:value
+    (first
+      (filter #(= (:key %) key) answers))))
+
+(defn- payment-to-invoice [payment application]
+  [:VA-invoice
+   [:Header
+    [:Maksuera (payment :installment)]
+    [:Laskunpaiva (:invoice-date payment)]
+    [:Erapvm (:due-date payment)]
+    [:Bruttosumma (:amount payment)]
+    [:Maksuehto "Z001"]
+    [:Pitkaviite (:long-ref payment)]
+    [:Tositepvm (:receipt-date payment)]
+    [:Asiatarkastaja (:inspector-email payment)]
+    [:Hyvaksyja (:acceptor-email payment)]
+    [:Tositelaji (:document-type payment)]
+     [:Toimittaja
+      [:Y-tunnus (get-answer-value (:answers application) "business-id")]
+      [:Nimi (:organization-name application)]
+      [:Postiosoite
+      (or (get-answer-value (:answers application) "address") "")]
+      [:Paikkakunta
+      (or (get-answer-value (:answers application) "city") "")]
+      [:Maa
+      (or (get-answer-value (:answers application) "country") "")]
+      [:Iban-tili
+      (get-answer-value (:answers application) "bank-iban")]
+      [:Pankkiavain
+      (get-answer-value (:answers application) "bank-bic")]
+      [:Pankki-maa
+      (or (get-answer-value (:answers application) "bank-country") "")]
+      [:Kieli (:language application)]
+      [:Valuutta (:currency payment)]]
+    [:Postings
+     [:Posting
+      [:Summa (:amount payment)]
+      [:LKP-tili (:lkp-account payment)]
+      [:TaKp-tili (:takp-account payment)]
+      [:Toimintayksikko (:operational-unit payment)]
+      [:Projekti (:project payment)]
+      [:Toiminto (:operation payment)]
+      [:Kumppani (:partner payment)]]]]])
+
+(defn payment-to-xml [payment application]
+  "Creates xml document (tags) of given payment of Valtionavustukset maksatus.
   Document should be valid document for VIA/Rondo."
-  (element invoice))
+  (sexp-as-element (payment-to-invoice payment application)))
 
 (defn tags-to-str [tags]
   "Converts XML document of clojure.data.xml.elements tags to a string."
@@ -21,5 +67,4 @@
   clojure.data.xml.elements."
   (with-open [input (java.io.FileInputStream. file)]
     (parse input)))
-
 

--- a/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
@@ -230,14 +230,14 @@
    (s/optional-key :ALV-koodi) s/Str
    :TaKp-tili s/Str
    :Toimintayksikko s/Str
-   :Valtuusnro s/Str
+   :Valtuusnro (s/optional-key s/Str)
    :Projekti s/Str
    :Toiminto s/Str
-   :Suorite s/Str
-   :AlueKunta s/Str
+   :Suorite (s/optional-key s/Str)
+   :AlueKunta (s/optional-key s/Str)
    :Kumppani s/Str
-   :Seuko1 s/Str
-   :Seuko2 s/Str
+   :Seuko1 (s/optional-key s/Str)
+   :Seuko2 (s/optional-key s/Str)
    (s/optional-key :Varalla1) s/Str
    (s/optional-key :Varalla2) s/Str})
 


### PR DESCRIPTION
Funktio jolla voi konvertoida hakemuksen ja maksatuksen XML-tiedostoksi.

Tämä osio tulee vielä jonkin verran muuttumaan. Esimerkiksi maksatuksen luontiprosessi saattaa muuttua, mutta nyt luodun funktion paluuarvo pitäisi pysyä samana.

Näin käytät replissä funktiota:
```
oph.va.virkailija.main=> (require '[oph.va.virkailija.invoice :as invoice] :reload)
nil
oph.va.virkailija.main=> (require '[oph.va.hakija.api :as hakija-api] :reload)
nil
oph.va.virkailija.main=> (def payment (dissoc (first (hakija-api/get-avustushaku-payments 1)) :grant-content))
#'oph.va.virkailija.main/payment
oph.va.virkailija.main=> (print (xml/indent-str (invoice/payment-to-xml payment application)))
...
nil
oph.va.virkailija.main=> (invoice/write-xml! (invoice/payment-to-xml payment application) "/tmp/invoice.xml")
#object[java.io.FileWriter 0x2857b8fa "java.io.FileWriter@2857b8fa"]
```

