### PR TITLE
Va3 99 via integration

### DIFF
--- a/parent-project.clj
+++ b/parent-project.clj
@@ -97,7 +97,8 @@
                          [org.clojure/tools.trace "0.7.9"]
                          [org.scala-lang.modules/scala-xml_2.11 "1.0.6"]
                          [org.scala-lang/scala-library "2.11.11"]
-                         [org.clojure/data.xml "0.0.8"]]
+                         [org.clojure/data.xml "0.0.8"]
+                         [clj-ssh "0.5.14"]]
 
   :pedantic? :abort
 

--- a/va-virkailija/config/defaults.edn
+++ b/va-virkailija/config/defaults.edn
@@ -38,8 +38,4 @@
          :print-mail-on-disable? true
          :retry-initial-wait 2000
          :retry-multiplier 4
-         :retry-max-time 60000}
- :ftp  {:host-ip "localhost"
-        :port 2222
-        :local_path "/tmp/"
-        :remote_path "/home/oph002/to_rondo/va/"}}
+         :retry-max-time 60000}}

--- a/va-virkailija/config/defaults.edn
+++ b/va-virkailija/config/defaults.edn
@@ -38,4 +38,8 @@
          :print-mail-on-disable? true
          :retry-initial-wait 2000
          :retry-multiplier 4
-         :retry-max-time 60000}}
+         :retry-max-time 60000}
+ :ftp  {:host-ip "localhost"
+        :port 2222
+        :local_path "/tmp/"
+        :remote_path "/home/oph002/to_rondo/va/"}}

--- a/va-virkailija/config/dev.edn
+++ b/va-virkailija/config/dev.edn
@@ -10,4 +10,11 @@
  :form-db {:database-name "va-dev"}
  :email {:enabled? false
          :host "localhost"
-         :port 2500}}
+         :port 2500
+         :to-finance ["test@test.com"]}
+ :ftp  {:host-ip "dockerftp"
+        :port 2222
+        :local_path "/tmp/"
+        :remote_path "/home/oph/to_rondo/va/"
+        :username "ansku"
+        :password "va"}}

--- a/va-virkailija/project.clj
+++ b/va-virkailija/project.clj
@@ -26,7 +26,7 @@
                  [org.clojars.pntblnk/clj-ldap]
                  [org.clojure/data.json]
                  [org.clojure/data.xml]
-                 [clj-ssh "0.5.14"]]
+                 [clj-ssh]]
 
   :profiles {:uberjar {:aot :all}
              :dev     {:env {:config "config/dev.edn"

--- a/va-virkailija/project.clj
+++ b/va-virkailija/project.clj
@@ -25,7 +25,8 @@
                  [org.http4s/http4s-blaze-client_2.11]
                  [org.clojars.pntblnk/clj-ldap]
                  [org.clojure/data.json]
-                 [org.clojure/data.xml]]
+                 [org.clojure/data.xml]
+                 [clj-ssh "0.5.14"]]
 
   :profiles {:uberjar {:aot :all}
              :dev     {:env {:config "config/dev.edn"

--- a/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
@@ -7,7 +7,6 @@
 
 ;(def haku (first (hakija-api/get-avustushaku-payments 2)))
 ;(def payment (dissoc haku :grant-content))
-
 (def ftp-config (:ftp config))
 
 (defn send-sftp [file]

--- a/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
@@ -1,15 +1,11 @@
-(ns oph.va.virkailija.ftp_service
+(ns oph.va.virkailija.ftp-service
   (:require [clj-ssh.ssh :as ssh]
             [oph.va.hakija.api :as hakija-api];
             [oph.va.virkailija.invoice :as invoice]
             [oph.soresu.common.config :refer [config]]))
 
 
-;(def haku (first (hakija-api/get-avustushaku-payments 2)))
-;(def payment (dissoc haku :grant-content))
-(def ftp-config (:ftp config))
-
-(defn send-sftp [file]
+(defn send-sftp [file ftp-config]
   (let [agent (ssh/ssh-agent {:use-system-ssh-agent false})
         session (ssh/session agent (ftp-config :host-ip) { :username (ftp-config :username) :password (ftp-config :password) :port (ftp-config :port) :strict-host-key-checking :no})]
         (ssh/with-connection session
@@ -19,6 +15,7 @@
 
 
 (defn send-to-rondo [payment application]
-  (let [file (str (ftp-config :local_path) "maksatus" "-" (payment :grant-id) "-" (payment :created-at) ".xml")]
+  (let [ftp-config (:ftp config)
+        file (str (ftp-config :local_path) "maksatus" "-" "avustushaku" "-" (payment :grant-id) "-" (System/currentTimeMillis) ".xml")]
   (invoice/write-xml! (invoice/payment-to-xml payment application) file)
-  (send-sftp file)))
+  (send-sftp file ftp-config)))

--- a/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
@@ -1,21 +1,25 @@
 (ns oph.va.virkailija.ftp_service
-  (:require [clj-ssh.ssh :refer all]
+  (:require [clj-ssh.ssh :as ssh]
             [oph.va.hakija.api :as hakija-api];
             [oph.va.virkailija.invoice :as invoice]
             [oph.soresu.common.config :refer [config]]))
 
 
-(def haku (first (hakija-api/get-avustushaku-payments 2)))
-(def payment (dissoc haku :grant-content))
+;(def haku (first (hakija-api/get-avustushaku-payments 2)))
+;(def payment (dissoc haku :grant-content))
+
 (def ftp-config (:ftp config))
 
-(defn send-to-ftp [payment]
-  (let [agent (ssh-agent {})
-        payment_file_name (str (payment :grant-id) "-" (payment :created-at) ".xml")
-        payment_xml   (invoice/write-xml! (invoice/tags-to-str payment) (str (ftp-config :local_path) "/" payment_file_name))]
-    (let [session (session agent (ftp-config :host-ip) {:strict-host-key-checking :no})]
-      (with-connection session
-        (let [channel (ssh-sftp session)]
-          (with-channel-connection channel
-            (sftp channel {} :cd (ftp-config :remote_path))
-            (sftp channel {} :put (ftp-config :local_path) payment_file_name)))))))
+(defn send-sftp [file]
+  (let [agent (ssh/ssh-agent {:use-system-ssh-agent false})
+        session (ssh/session agent (ftp-config :host-ip) { :username (ftp-config :username) :password (ftp-config :password) :port (ftp-config :port) :strict-host-key-checking :no})]
+        (ssh/with-connection session
+          (let [channel (ssh/ssh-sftp session)]
+            (ssh/with-channel-connection channel
+              (ssh/sftp channel {} :put file (ftp-config :remote_path)))))))
+
+
+(defn send-to-rondo [payment application]
+  (let [file (str (ftp-config :local_path) "maksatus" "-" (payment :grant-id) "-" (payment :created-at) ".xml")]
+  (invoice/write-xml! (invoice/payment-to-xml payment application) file)
+  (send-sftp file)))

--- a/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/ftp_service.clj
@@ -1,0 +1,21 @@
+(ns oph.va.virkailija.ftp_service
+  (:require [clj-ssh.ssh :refer all]
+            [oph.va.hakija.api :as hakija-api];
+            [oph.va.virkailija.invoice :as invoice]
+            [oph.soresu.common.config :refer [config]]))
+
+
+(def haku (first (hakija-api/get-avustushaku-payments 2)))
+(def payment (dissoc haku :grant-content))
+(def ftp-config (:ftp config))
+
+(defn send-to-ftp [payment]
+  (let [agent (ssh-agent {})
+        payment_file_name (str (payment :grant-id) "-" (payment :created-at) ".xml")
+        payment_xml   (invoice/write-xml! (invoice/tags-to-str payment) (str (ftp-config :local_path) "/" payment_file_name))]
+    (let [session (session agent (ftp-config :host-ip) {:strict-host-key-checking :no})]
+      (with-connection session
+        (let [channel (ssh-sftp session)]
+          (with-channel-connection channel
+            (sftp channel {} :cd (ftp-config :remote_path))
+            (sftp channel {} :put (ftp-config :local_path) payment_file_name)))))))


### PR DESCRIPTION
Jees, tässä branchissa siis ei vielä toteutettu sitä apia, vaan ainoastaan se ftp-toiminnallisuus, jolla voi lähettää olemassaolevia maksatuksia configuraatiossa annettuun ftp-palvelimeen. 

**Testaus**

0) Konffaa joku testi ftp. Itse käytin tätä: https://hub.docker.com/r/atmoz/sftp/ 

1) Lisää mokkiftp:n konfiguraatiot dev.edn-filuun 
```
:ftp  {:host-ip "your host"
       :port 2222
       :local_path "/tmp/"
       :remote_path "your path"
       :username "your username"
       :password "your password"}
```

2)avaa repli va-virkailija:ssa

```
oph.va.virkailija.main=>  (require '[oph.va.virkailija.ftp_service :as ftpservice] :reload)
oph.va.virkailija.main=>  (require '[oph.va.hakija.api :as hakija-api] :reload)
oph.va.virkailija.main=>  (require '[oph.va.virkailija.invoice :as invoice] :reload)
oph.va.virkailija.main=>  (require '[oph.soresu.common.config :refer [config]] :reload)
oph.va.virkailija.main=>  (def haku (first (hakija-api/get-avustushaku-payments 2)))
oph.va.virkailija.main=>  (def payment (dissoc haku :grant-content))
oph.va.virkailija.main=>  (def application 1)
oph.va.virkailija.main=>  (def ftp-config (:ftp config))

oph.va.virkailija.main=> (ftpservice/send-to-rondo payment application)
```

3) Kurkkaa, että filu on siirtynyt oikein. 