### PR TITLE
added link to the application-table by using application id and grant id

### DIFF
--- a/va-payments-ui/src/va_payments_ui/applications.cljs
+++ b/va-payments-ui/src/va_payments_ui/applications.cljs
@@ -32,7 +32,7 @@
    [ui/table-row-column (get-in application [:arvio :takp-account])]
    [ui/table-row-column (get-in application [:arvio :amount])]])
 
-(defn applications-table [applications grant-id]
+(defn applications-table [applications]
   [:div
    [ui/table {:fixed-header true :height "250px" :selectable false}
     [ui/table-header {:adjust-for-checkbox false :display-select-all false}

--- a/va-payments-ui/src/va_payments_ui/applications.cljs
+++ b/va-payments-ui/src/va_payments_ui/applications.cljs
@@ -48,4 +48,4 @@
       [ui/table-header-column "Tiliöintisumma"]]]
     [ui/table-body {:display-row-checkbox false}
      (doall
-       (map-indexed render-application (map #(assoc % :grant-id grant-id) applications)))]]])
+       (map-indexed render-application applications))]]])

--- a/va-payments-ui/src/va_payments_ui/applications.cljs
+++ b/va-payments-ui/src/va_payments_ui/applications.cljs
@@ -23,7 +23,7 @@
   [ui/table-row {:key i}
    [ui/table-row-column (state-to-str (:payment-state application))]
    [ui/table-row-column (:organization-name application)]
-   [ui/table-row-column (:project-name application)]
+   [ui/table-row-column [:a {:href (str "/avustushaku/" (:grant-id application) "/hakemus/"(:id application) "/arviointi/")} (:project-name application)]]
    [ui/table-row-column (get application :budget-granted)]
    [ui/table-row-column
     (get-answer-value (:answers application) "bank-iban")]
@@ -32,7 +32,7 @@
    [ui/table-row-column (get-in application [:arvio :takp-account])]
    [ui/table-row-column (get-in application [:arvio :amount])]])
 
-(defn applications-table [applications]
+(defn applications-table [applications grant-id]
   [:div
    [ui/table {:fixed-header true :height "250px" :selectable false}
     [ui/table-header {:adjust-for-checkbox false :display-select-all false}
@@ -48,4 +48,4 @@
       [ui/table-header-column "Tiliöintisumma"]]]
     [ui/table-body {:display-row-checkbox false}
      (doall
-       (map-indexed render-application applications))]]])
+       (map-indexed render-application (map #(assoc % :grant-id grant-id) applications)))]]])

--- a/va-payments-ui/src/va_payments_ui/applications.cljs
+++ b/va-payments-ui/src/va_payments_ui/applications.cljs
@@ -23,7 +23,7 @@
   [ui/table-row {:key i}
    [ui/table-row-column (state-to-str (:payment-state application))]
    [ui/table-row-column (:organization-name application)]
-   [ui/table-row-column [:a {:href (str "/avustushaku/" (:grant-id application) "/hakemus/"(:id application) "/arviointi/")} (:project-name application)]]
+   [ui/table-row-column [:a {:target "_blank" :href (str "/avustushaku/" (:grant-id application) "/hakemus/"(:id application) "/arviointi/")} (:project-name application)]]
    [ui/table-row-column (get application :budget-granted)]
    [ui/table-row-column
     (get-answer-value (:answers application) "bank-iban")]

--- a/va-payments-ui/src/va_payments_ui/core.cljs
+++ b/va-payments-ui/src/va_payments_ui/core.cljs
@@ -141,9 +141,9 @@
    [:a {:href "/admin/"} "Hakujen hallinta"]
    [:a {:href "/va-payments-ui/payments"} "Maksatusten hallinta"]])
 
-(defn render-applications [applications grant-id]
+(defn render-applications [applications]
  [:div
-  (applications/applications-table applications grant-id)])
+  (applications/applications-table applications)])
 
 (defn role-select [value on-change]
   [ui/select-field {:value value :floating-label-text "Rooli"
@@ -228,7 +228,7 @@
             [:div
             [:h3 "Myönteiset päätökset"]
             [:div (project-info grant)]
-             (render-applications current-applications (:id grant))
+             (render-applications current-applications)
                [:div
                 (when (= @user-role "presenting_officer")
                   (when-let [grant (nth @grants @selected-grant)]

--- a/va-payments-ui/src/va_payments_ui/core.cljs
+++ b/va-payments-ui/src/va_payments_ui/core.cljs
@@ -141,9 +141,9 @@
    [:a {:href "/admin/"} "Hakujen hallinta"]
    [:a {:href "/va-payments-ui/payments"} "Maksatusten hallinta"]])
 
-(defn render-applications [applications]
+(defn render-applications [applications grant-id]
  [:div
-  (applications/applications-table applications)])
+  (applications/applications-table applications grant-id)])
 
 (defn role-select [value on-change]
   [ui/select-field {:value value :floating-label-text "Rooli"
@@ -228,7 +228,7 @@
             [:div
             [:h3 "Myönteiset päätökset"]
             [:div (project-info grant)]
-             (render-applications current-applications)
+             (render-applications current-applications (:id grant))
                [:div
                 (when (= @user-role "presenting_officer")
                   (when-let [grant (nth @grants @selected-grant)]

--- a/va-virkailija/resources/sql/hakija/grants/get-grant-applications-with-evaluation.sql
+++ b/va-virkailija/resources/sql/hakija/grants/get-grant-applications-with-evaluation.sql
@@ -1,7 +1,6 @@
 SELECT
   h.id, h.created_at, h.version, h.budget_total, h.budget_oph_share,
-  h.organization_name, h.project_name, h.register_number, h.language,
-  s.answers->'value' AS answers, a.budget_granted, a.costs_granted
+  h.organization_name, h.project_name, h.register_number, h.language, h.avustushaku AS grant_id, s.answers->'value' AS answers, a.budget_granted, a.costs_granted
 FROM
   hakija.hakemukset h
 JOIN

--- a/va-virkailija/resources/sql/hakija/grants/get-grant-applications.sql
+++ b/va-virkailija/resources/sql/hakija/grants/get-grant-applications.sql
@@ -1,7 +1,6 @@
 SELECT
   h.id, h.created_at, h.version, h.budget_total, h.budget_oph_share,
-  h.organization_name, h.project_name, h.register_number, h.language,
-  s.answers->'value' AS answers
+  h.organization_name, h.project_name, h.register_number, h.language, h.avustushaku AS grant_id, s.answers->'value' AS answers
 FROM
   hakija.hakemukset h
 JOIN

--- a/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
@@ -313,5 +313,6 @@
    :language s/Str
    :budget-granted s/Int
    :costs-granted s/Int
+   (s/optional-key :grant-id) s/Int
    (s/optional-key :evaluation) s/Any
    (s/optional-key :answers) [Answer]})


### PR DESCRIPTION
Elikäs periaatteessa pikkujuttu eli tuohon applications.cljs:n render-applicationssiin vaan sen nimen sijaan piti lisätä linkki. 
Ainoa mutka tossa tuli siitä, että se linkki on muotoa 
/avustushaku/<grant-id>/hakemus/<application-id>/arviointi/

.. ja tuo grant-id ei enää ui siellä applications.cljssä. Onkohan tähän joku järkevä tapa, miten saisi applicationssista tuon grant-id:n? Mä tein tolleen tyhmästi, ehkä, että uitin sieltä core.cljs:stä (rivi 231) sen grant-id:n messissä
(render-applications current-applications (:id grant)) 
.. ja sitten sinne render-applicationssiin 
`(defn render-applications [applications grant-id]
 [:div
  (applications/applications-table applications grant-id)])`
..ja siitäkin vielä sit sinne applications.cljs:ään. 
Lisäksi siellä sitten se applications-table kutsuu aina yhdellä hakemuksella sitä render-applicationsia, joten siinäkin tolleen vähän rumasti tungin sen grant-id:n sit yksittäiseen applicationssiin (rivi 51 applications.cljs:ssä). 

Että mielelläni kuulen, että miten ton ois voinut tehdä nätimmin? 