### PR TITLE
Va3 176 clean application payment combinations

### DIFF
--- a/va-payments-ui/src/va_payments_ui/applications.cljs
+++ b/va-payments-ui/src/va_payments_ui/applications.cljs
@@ -23,7 +23,7 @@
 (defn render-application
   [i application on-info-clicked]
   [ui/table-row {:key i}
-   [ui/table-row-column (state-to-str (:payment-state application))]
+   [ui/table-row-column (state-to-str (get-in application [:payment :state]))]
    [ui/table-row-column (:organization-name application)]
    [ui/table-row-column
     [:a

--- a/va-payments-ui/src/va_payments_ui/financing.cljs
+++ b/va-payments-ui/src/va_payments_ui/financing.cljs
@@ -2,7 +2,6 @@
   (:require [reagent.core :as r]
             [cljsjs.material-ui]
             [cljs-react-material-ui.reagent :as ui]
-            [va-payments-ui.payments :refer [get-payment-data]]
             [va-payments-ui.theme :as theme]
             [va-payments-ui.utils :refer
              [remove-nil any-nil? not-nil? not-empty?]]))

--- a/va-payments-ui/src/va_payments_ui/payments.cljs
+++ b/va-payments-ui/src/va_payments_ui/payments.cljs
@@ -77,15 +77,6 @@
    [ui/table-body {:display-row-checkbox false}
     (doall (map-indexed render-history-item payments))]])
 
-(defn combine-application-payment
-  [application payment]
-  (let [selected-values (select-keys payment [:id :version :state])]
-    (merge application
-           (clojure.set/rename-keys selected-values
-                                    {:id :payment-id
-                                     :version :payment-version
-                                     :state :payment-state}))))
-
 (defn find-application-payment
   [payments application-id application-version]
   (first (filter #(and (= (:application-version %) application-version)
@@ -94,7 +85,6 @@
 
 (defn combine
   [applications payments]
-  (mapv #(combine-application-payment
-           %
-           (find-application-payment payments (:id %) (:version %)))
+  (mapv
+    #(assoc % :payment (find-application-payment payments (:id %) (:version %)))
     applications))

--- a/va-payments-ui/src/va_payments_ui/payments.cljs
+++ b/va-payments-ui/src/va_payments_ui/payments.cljs
@@ -53,6 +53,6 @@
 
 (defn combine
   [applications payments]
-  (mapv
-    #(assoc % :payment (find-application-payment payments (:id %) (:version %)))
+  (mapv #(assoc %
+          :payment (find-application-payment payments (:id %) (:version %)))
     applications))

--- a/va-payments-ui/src/va_payments_ui/payments.cljs
+++ b/va-payments-ui/src/va_payments_ui/payments.cljs
@@ -8,38 +8,6 @@
 (def date-formatter (tf/formatter "dd.MM.yyyy"))
 (def date-time-formatter (tf/formatter "dd.MM.yyyy HH:mm"))
 
-(defn map-to-new-payment
-  [application]
-  {:application-id (:id application)
-   :application-version (:version application)
-   :state 0})
-
-(defn create-payments
-  [grant applications payment-values]
-  (let [selected-values (select-keys payment-values
-                                     [:document-type :transaction-account
-                                      :currency :partner :inspector-email
-                                      :acceptor-email])]
-    (mapv #(merge (map-to-new-payment %) selected-values) applications)))
-
-(defn map-to-payment
-  [application]
-  {:id (:payment-id application)
-   :version (:payment-version application)
-   :application-id (:id application)
-   :application-version (:version application)})
-
-(defn get-payment-data
-  [applications payment-values]
-  (let [selected-values (merge (select-keys
-                                 payment-values
-                                 [:installment-number :organisation
-                                  :document-type :invoice-date :due-date
-                                  :receipt-date :transaction-account :currency
-                                  :partner :inspector-email :acceptor-email])
-                               {:state (:payment-state payment-values)})]
-    (mapv #(merge (map-to-payment %) selected-values) applications)))
-
 (defn to-simple-date [d] (tf/unparse-local date-formatter (tf/parse d)))
 
 (defn to-simple-date-time


### PR DESCRIPTION
Korvataan monimutkaiset mäppäykset pelkästään :payments - assoc -kombinaatiolla.

Samalla poistettu muutama funktio, mitkä tähän operaation liittyi jollain tavalla.