### PR TITLE
Va3 222 oph styled components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 **/checkouts/
 **/resources/public/js/
 **/resources/public/admin-ui/js
+**/resources/public/admin-ui/css/*-min.css
+/va-admin-ui/package*
 *.iml
 .*.swp
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ lein-clean-targets:
 .PHONY: lein-clean-admin-frontend
 lein-clean-admin-frontend:
 	rm -fr va-virkailija/resources/public/admin-ui/js
+	rm -f va-virkailija/resources/public/admin-ui/css/*-min.css
+	rm -f va-admin-ui/package*.json
+	rm -rf va-admin-ui/node_modules
 
 .PHONY: lein-build
 lein-build: lein-install-jar-commons lein-build-admin-frontend lein-build-backends

--- a/va-admin-ui/README.md
+++ b/va-admin-ui/README.md
@@ -10,10 +10,20 @@ Pääkäyttäjän käyttöliittymä
 
 ## Kehitysympäristö
 
-1. Käynnistä va-virkailija
-2. Käynnistä Figwheel-kääntäjä
+1. Käännä riippuvuudet `make clean build`
+2. Käynnistä va-virkailija
+3. Käynnistä Figwheel-kääntäjä
 
-Figwheel compiler lähtee käyntiin komennolla:
+Figwheel kannattaa ajaa suoraan REPL:stä (esim. Emacs Cider):
+
+``` bash
+lein repl
+# user=> (use 'figwheel-sidecar.repl-api)
+# user=> (start-figwheel!)
+# user=> (cljs-repl)
+```
+
+Figwheel compiler lähtee käyntiin myös komennolla:
 
 ``` bash
 ../lein figwheel
@@ -25,18 +35,9 @@ Kääntäjä luo buildin hakemistoon
 Figwheel puskee muutokset `.cljs`-tiedostoissa selaimelle. Kun Figwheel
 on käynnistynyt, pitäisi selaimeen aueta `/admin-ui/`.
 
-### REPL
+### Vaihtoehtoinen REPL
 
-Figwheelin voi käynnistää REPL:n kautta:
-
-``` bash
-lein repl
-# user=> (use 'figwheel-sidecar.repl-api)
-# user=> (start-figwheel!)
-# user=> (cljs-repl)
-```
-
-rlwrap toimii Figwheelin kanssa:
+Myös rlwrap toimii Figwheelin kanssa:
 
 ``` bash
 rlwrap lein figwheel

--- a/va-admin-ui/project.clj
+++ b/va-admin-ui/project.clj
@@ -54,8 +54,6 @@
       :output-to "../va-virkailija/resources/public/admin-ui/js/app.js"
       :output-dir "../va-virkailija/resources/public/admin-ui/js/out"
       :asset-path "/admin-ui/js/out"
-      :install-deps true
-      :npm-deps {:oph-virkailija-style-guide "git+https://github.com/Opetushallitus/virkailija-styles.git"}
       :source-map true
       :optimizations :none
       :pretty-print  true}

--- a/va-admin-ui/project.clj
+++ b/va-admin-ui/project.clj
@@ -4,7 +4,8 @@
   :plugins [[lein-parent "0.3.2"]
             [lein-cljsbuild "1.1.7"]
             [lein-figwheel "0.5.14"]
-            [lein-doo "0.1.8"]]
+            [lein-doo "0.1.8"]
+            [lein-asset-minifier "0.4.4"]]
 
   :source-paths ["src"]
 
@@ -39,6 +40,11 @@
              :nrepl-port 7002
              :nrepl-middleware ["cemerick.piggieback/wrap-cljs-repl"]
              :css-dirs ["../va-virkailija/resources/public/admin-ui/css"]}
+
+  :minify-assets [[:css
+                   {:source "node_modules/oph-virkailija-style-guide/oph-styles.css"
+                    :target "../va-virkailija/resources/public/admin-ui/css/oph-styles-min.css"}]]
+
   :cljsbuild
   {:builds
    {:app
@@ -48,6 +54,8 @@
       :output-to "../va-virkailija/resources/public/admin-ui/js/app.js"
       :output-dir "../va-virkailija/resources/public/admin-ui/js/out"
       :asset-path "/admin-ui/js/out"
+      :install-deps true
+      :npm-deps {:oph-virkailija-style-guide "git+https://github.com/Opetushallitus/virkailija-styles.git"}
       :source-map true
       :optimizations :none
       :pretty-print  true}
@@ -59,6 +67,8 @@
      :compiler
      {:output-to "../va-virkailija/resources/public/admin-ui/js/app.js"
       :output-dir "../va-virkailija/resources/public/admin-ui/js/release"
+      :install-deps true
+      :npm-deps {:oph-virkailija-style-guide "git+https://github.com/Opetushallitus/virkailija-styles.git"}
       :asset-path "/admin-ui/js/out"
       :optimizations :advanced
       :pretty-print false}}
@@ -75,7 +85,7 @@
   :doo {:build "test"
         :alias {:default [:node]}}
 
-  :aliases {"package" ["do" "clean" ["cljsbuild" "once" "release"]]}
+  :aliases {"package" ["do" "clean" ["cljsbuild" "once" "release"] "minify-assets"]}
 
   :profiles {:dev {:dependencies [[com.cemerick/piggieback]
                                   [binaryage/devtools]

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -7,7 +7,7 @@
 
 (defn default-style [style]
   (if (nil? (:margin style))
-      (assoc style :margin "5px")
+      (assoc style :margin "5px" :display "inline-block")
       style))
 
 (defn text-field [p]
@@ -23,7 +23,7 @@
       [:div {:class "oph-field-text"} help-text])]))
 
 (defn select-field [props values]
-  [:div {:class "oph-field"}
+  [:div {:class "oph-field" :style (default-style (:style props))}
    [:label {:class "oph-label"} (or (:label props)
                                     (:floating-label-text props))]
    [:div {:class "oph-select-container"}
@@ -37,7 +37,7 @@
 
 (defn date-picker [props]
   (let [label (or (:floating-label-text props) (:label props))]
-   [:div {:class "oph-field"}
+   [:div {:class "oph-field" :style (default-style (:style props))}
     [:span {:class "oph-label" :aria-describedby "field-text"} label]
     [material/date-picker {:value (:value props)
                            :class "oph-input"
@@ -48,7 +48,8 @@
                                               :height "auto"
                                               :line-height "inherit"
                                               :font-family "inherit"}
-                           :input-style {}}]]))
+                           :input-style {}
+                           :on-change (:on-change props)}]]))
 
 (defn menu-item [props]
   [:option {:value (:value props)} (:primary-text props)])

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -1,6 +1,8 @@
 (ns oph.va.admin-ui.components.ui
   (:require [clojure.string :as string]
             [reagent.core :as r]
+            [cljsjs.material-ui]
+            [cljs-react-material-ui.reagent :as material]
             [oph.va.admin-ui.theme :as theme]))
 
 (defn default-style [style]
@@ -19,6 +21,24 @@
              :class str "oph-input")]
     (when-some [help-text (:help-text props)]
       [:div {:class "oph-field-text"} help-text])]))
+
+(defn date-picker [props]
+  (let [label (or (:floating-label-text props) (:label props))]
+   [:div {:class "oph-field"}
+    [:span {:class "oph-label" :aria-describedby "field-text"} label]
+    [material/date-picker {:value (:value props)
+                           :class "oph-input"
+                           :name label
+                           :underline-show false
+                           :style {:width "auto" :height "auto"}
+                           :text-field-style {:width "auto"
+                                              :height "auto"
+                                              :line-height "inherit"
+                                              :font-family "inherit"}
+                           :input-style {}}]]))
+
+(defn menu-item [props]
+  [:option {:value (:value props)} (:primary-text props)])
 
 (defn remove-nils [c] (disj c nil))
 

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -13,7 +13,7 @@
     [:span {:class "oph-label" :aria-describedby "field-text"}
      (:label-text props)]
     [:input
-     (update (select-keys props [:value :type :onchange])
+     (update (select-keys props [:value :type :on-change])
              :class str "oph-input")]
     (when-some [help-text (:help-text props)]
       [:div {:class "oph-field-text"} help-text])]))

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -22,6 +22,19 @@
     (when-some [help-text (:help-text props)]
       [:div {:class "oph-field-text"} help-text])]))
 
+(defn select-field [props values]
+  [:div {:class "oph-field"}
+   [:label {:class "oph-label"} (or (:label props)
+                                    (:floating-label-text props))]
+   [:div {:class "oph-select-container"}
+    [:select {:class "oph-input oph-select"
+              :value (or (:value props) "")
+              :on-change #((:on-change props) (.-value (.-target %))) }
+     (for [value values]
+       [:option {:value (:value value)
+                 :key (:value value)}
+        (:primary-text value)])]]])
+
 (defn date-picker [props]
   (let [label (or (:floating-label-text props) (:label props))]
    [:div {:class "oph-field"}

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -39,6 +39,8 @@
        (update :style default-style))
    (:label p)])
 
+(def raised-button button)
+
 (defn tabs [children]
   (let [selected (r/atom 0)]
    (fn [children]

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -17,7 +17,8 @@
     [:span {:class "oph-label" :aria-describedby "field-text"}
      (:label-text props)]
     [:input
-     (update (select-keys props [:value :type :on-change])
+     (update (select-keys props [:value :type :on-change :type :size :min :max
+                                 :max-length])
              :class str "oph-input")]
     (when-some [help-text (:help-text props)]
       [:div {:class "oph-field-text"} help-text])]))

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -1,5 +1,6 @@
 (ns oph.va.admin-ui.components.ui
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [reagent.core :as r]))
 
 (defn default-style [style]
   (if (nil? (:margin style))
@@ -37,3 +38,21 @@
        (assoc :class (generate-button-class p))
        (update :style default-style))
    (:label p)])
+
+(defn tabs [children]
+  (let [selected (r/atom 0)]
+   (fn [children]
+    [:div {:class "oph-typography"}
+     [:div {:class "oph-tabs"}
+      (doall
+        (map-indexed
+          (fn [i c]
+            [:a {:key i
+                 :on-click #(reset! selected i)
+                 :class
+                 (str "oph-tab-item"
+                      (when (= @selected i) " oph-tab-item-is-active"))}
+             (:label c)])
+          children))]
+     [:div
+      (get-in children [@selected :content])]])))

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -1,6 +1,7 @@
 (ns oph.va.admin-ui.components.ui
   (:require [clojure.string :as string]
-            [reagent.core :as r]))
+            [reagent.core :as r]
+            [oph.va.admin-ui.theme :as theme]))
 
 (defn default-style [style]
   (if (nil? (:margin style))
@@ -45,11 +46,12 @@
   (let [selected (r/atom 0)]
    (fn [children]
     [:div {:class "oph-typography"}
-     [:div {:class "oph-tabs" :style {:cursor "pointer"}}
+     [:div {:class "oph-tabs" :style theme/tabs-header}
       (doall
         (map-indexed
           (fn [i c]
             [:a {:key i
+                 :style theme/tab-header-link
                  :on-click #(reset! selected i)
                  :class
                  (str "oph-tab-item"

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -8,7 +8,7 @@
 
 (defn default-style [style]
   (if (nil? (:margin style))
-      (assoc style :margin "5px" :display "inline-block")
+      (merge theme/text-field style)
       style))
 
 (defn text-field [p]

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -1,0 +1,39 @@
+(ns oph.va.admin-ui.components.ui
+  (:require [clojure.string :as string]))
+
+(defn default-style [style]
+  (if (nil? (:margin style))
+      (assoc style :margin "5px")
+      style))
+
+(defn text-field [p]
+  (let [props
+        (assoc p :label-text (or (:floating-label-text p) (:label-text p)))]
+   [:div {:class "oph-field" :style (default-style (:style p))}
+    [:span {:class "oph-label" :aria-describedby "field-text"}
+     (:label-text props)]
+    [:input
+     (update (select-keys props [:value :type :onchange])
+             :class str "oph-input")]
+    (when-some [help-text (:help-text props)]
+      [:div {:class "oph-field-text"} help-text])]))
+
+(defn remove-nils [c] (disj c nil))
+
+(defn generate-button-class [props]
+  (->> (hash-set
+         "oph-button"
+         (:class props)
+         (when (:disabled props) "oph-button-disabled")
+         (when (:primary props) "oph-button-primary"))
+       remove-nils
+       (string/join " ")
+       string/trim))
+
+(defn button [p]
+  [:button
+   (-> p
+       (select-keys [:on-click :style :disabled])
+       (assoc :class (generate-button-class p))
+       (update :style default-style))
+   (:label p)])

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -45,7 +45,7 @@
   (let [selected (r/atom 0)]
    (fn [children]
     [:div {:class "oph-typography"}
-     [:div {:class "oph-tabs"}
+     [:div {:class "oph-tabs" :style {:cursor "pointer"}}
       (doall
         (map-indexed
           (fn [i c]

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -6,15 +6,10 @@
              :rename {date-picker material-date-picker}]
             [oph.va.admin-ui.theme :as theme]))
 
-(defn default-style [style]
-  (if (nil? (:margin style))
-      (merge theme/text-field style)
-      style))
-
 (defn text-field [p]
   (let [props
         (assoc p :label-text (or (:floating-label-text p) (:label-text p)))]
-   [:div {:class "oph-field" :style (default-style (:style p))}
+   [:div {:class "oph-field" :style (merge theme/text-field (:style p))}
     [:span {:class "oph-label" :aria-describedby "field-text"}
      (:label-text props)]
     [:input
@@ -25,7 +20,7 @@
       [:div {:class "oph-field-text"} help-text])]))
 
 (defn select-field [props values]
-  [:div {:class "oph-field" :style (default-style (:style props))}
+  [:div {:class "oph-field" :style (merge theme/select-field (:style props))}
    [:label {:class "oph-label"} (or (:label props)
                                     (:floating-label-text props))]
    [:div {:class "oph-select-container"}
@@ -39,7 +34,7 @@
 
 (defn date-picker [props]
   (let [label (or (:floating-label-text props) (:label props))]
-   [:div {:class "oph-field" :style (default-style (:style props))}
+   [:div {:class "oph-field" :style (merge theme/date-picker (:style props))}
     [:span {:class "oph-label" :aria-describedby "field-text"} label]
     [material-date-picker {:value (:value props)
                            :class "oph-input"
@@ -65,12 +60,15 @@
        (string/join " ")
        string/trim))
 
+(defn set-button-style [props]
+  (assoc props :style (merge theme/button (:style props))))
+
 (defn button [p]
   [:button
    (-> p
        (select-keys [:on-click :style :disabled])
        (assoc :class (generate-button-class p))
-       (update :style default-style))
+       set-button-style)
    (:label p)])
 
 (def raised-button button)

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -2,7 +2,8 @@
   (:require [clojure.string :as string]
             [reagent.core :as r]
             [cljsjs.material-ui]
-            [cljs-react-material-ui.reagent :as material]
+            [cljs-react-material-ui.reagent :refer [date-picker]
+             :rename {date-picker material-date-picker}]
             [oph.va.admin-ui.theme :as theme]))
 
 (defn default-style [style]
@@ -40,7 +41,7 @@
   (let [label (or (:floating-label-text props) (:label props))]
    [:div {:class "oph-field" :style (default-style (:style props))}
     [:span {:class "oph-label" :aria-describedby "field-text"} label]
-    [material/date-picker {:value (:value props)
+    [material-date-picker {:value (:value props)
                            :class "oph-input"
                            :name label
                            :underline-show false

--- a/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/components/ui.cljs
@@ -52,9 +52,6 @@
                            :input-style {}
                            :on-change (:on-change props)}]]))
 
-(defn menu-item [props]
-  [:option {:value (:value props)} (:primary-text props)])
-
 (defn remove-nils [c] (disj c nil))
 
 (defn generate-button-class [props]

--- a/va-admin-ui/src/oph/va/admin_ui/payments/financing.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/payments/financing.cljs
@@ -2,6 +2,7 @@
   (:require [reagent.core :as r]
             [cljsjs.material-ui]
             [cljs-react-material-ui.reagent :as ui]
+            [oph.va.admin-ui.components.ui :as va-ui]
             [oph.va.admin-ui.theme :as theme]
             [oph.va.admin-ui.payments.utils :refer
              [remove-nil any-nil? not-nil? not-empty? valid-email?]]))
@@ -21,7 +22,7 @@
 (defn payment-emails
   [values on-change]
   [ui/grid-list {:cols 6 :cell-height "auto"}
-   [ui/text-field
+   [va-ui/text-field
     {:floating-label-text "Tarkastajan sähköpostiosoite"
      :value (get values :inspector-email "")
      :type "email"
@@ -29,7 +30,7 @@
                                  (not (valid-email? (:inspector-email values))))
                         theme/text-field-error)
      :on-change #(on-change :inspector-email (.-value (.-target %)))}]
-   [ui/text-field
+   [va-ui/text-field
     {:floating-label-text "Hyväksyjän sähköpostiosoite"
      :value (get values :acceptor-email "")
      :type "email"
@@ -41,38 +42,38 @@
 (defn payment-fields
   [values on-change]
   [ui/grid-list {:cols 4 :cell-height "auto"}
-   [ui/select-field
+   [va-ui/select-field
     {:floating-label-text "Maksuliikemenotili"
      :value (get values :transaction-account)
-     :on-change #(on-change :transaction-account %3)}
-    (for [acc transaction-accounts]
-      [ui/menu-item {:key acc :value acc :primary-text acc}])]
-   [ui/date-picker
+     :on-change #(on-change :transaction-account %)}
+    (map (fn [acc] {:key acc :value acc :primary-text acc})
+         transaction-accounts)]
+   [va-ui/date-picker
     {:floating-label-text "Eräpäivä"
      :value (:due-date values)
      :on-change #(on-change :due-date %2)}]
-   [ui/date-picker
+   [va-ui/date-picker
     {:floating-label-text "Laskun päivämäärä"
      :value (:invoice-date values)
      :on-change #(on-change :invoice-date %2)}]
-   [ui/select-field
+   [va-ui/select-field
     {:floating-label-text "Tositelaji"
      :value (get values :document-type "XA")
-     :on-change #(on-change :document-type %3)}
-    [ui/menu-item {:value "XA" :primary-text "XA"}]
-    [ui/menu-item {:value "XB" :primary-text "XB"}]]
-   [ui/date-picker
+     :on-change #(on-change :document-type %)}
+    [{:value "XA" :primary-text "XA"}
+     {:value "XB" :primary-text "XB"}]]
+   [va-ui/date-picker
     {:floating-label-text "Tositepäivämäärä"
      :style {:display "inline-block"}
      :value (:receipt-date values)
      :on-change #(on-change :receipt-date %2)}]
-   [ui/text-field
+   [va-ui/text-field
     {:floating-label-text "Kumppanikoodi"
      :value (get values :partner "")
      :on-change (fn [e]
                   (let [value (.-value (.-target e))]
                     (when (<= (count value) 6) (on-change :partner value))))}]
-   [ui/text-field
+   [va-ui/text-field
     {:floating-label-text "Asiakirjan tunnus"
      :value (get values :document-id "")
      :on-change (fn [e]

--- a/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
@@ -170,6 +170,11 @@
 (defn notice [message]
   [:div {:style theme/notice} message])
 
+(defn any-account-nil? [a]
+  (some?
+    (some #(when-not (and (some? (get % :lkp-account))
+                          (some? (get % :takp-account))) %) a)))
+
 (defn home-page [{:keys [user-info delete-payments?]}]
   [:div
    [:div
@@ -221,9 +226,7 @@
                     (select-keys result [:status :error-text])))))))
         :is-admin? (user/is-admin? user-info)})]
     (let [multipayment? (get-in @selected-grant [:content :multiplemaksuera])
-          accounts-nil? (some #(when-not (or (get % :lkp-account)
-                                             (get % :takp-account)) true)
-                              @current-applications)
+          accounts-nil? (any-account-nil? @current-applications)
           unsent-payments? (some
                              #(when (< (get-in % [:payment :state]) 2) true)
                              @current-applications)]

--- a/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
@@ -8,6 +8,7 @@
     [cljs-react-material-ui.core :refer [color]]
     [cljs-react-material-ui.reagent :as ui]
     [cljs-react-material-ui.icons :as ic]
+    [oph.va.admin-ui.components.ui :as va-ui]
     [oph.va.admin-ui.payments.payments-ui :as payments-ui]
     [oph.va.admin-ui.payments.payments :as payments]
     [oph.va.admin-ui.payments.applications :as applications]
@@ -59,7 +60,7 @@
   [:div
    [:hr]
    [ui/grid-list {:cols 6 :cell-height "auto"}
-    [ui/raised-button
+    [va-ui/raised-button
      {:primary true
       :label "Poista maksatukset"
       :style theme/button
@@ -83,7 +84,7 @@
 
 (defn render-grant-filters [values on-change]
   [:div
-   [ui/text-field
+   [va-ui/text-field
     {:floating-label-text "Hakujen suodatus"
      :value (:filter-str values)
      :on-change #(on-change :filter-str (.-value (.-target %)))}]
@@ -233,7 +234,7 @@
        (when accounts-nil?
          (notice "Joillakin hakemuksilla ei ole LKP- tai TaKP-tiliä, joten
                    makastukset tulee luoda manuaalisesti."))
-       [ui/raised-button
+       [va-ui/raised-button
         {:primary true
          :disabled
          (or

--- a/va-admin-ui/src/oph/va/admin_ui/theme.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/theme.cljs
@@ -29,4 +29,4 @@
 
 (def notice {:padding "10px"})
 
-(def text-field {:margin-right 15})
+(def text-field {:margin-right 15 :display "inline-block"})

--- a/va-admin-ui/src/oph/va/admin_ui/theme.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/theme.cljs
@@ -10,8 +10,6 @@
              :picker-header-color "#4c7f00"
              :accent1-color "#00b5f0"}})
 
-(def button {:margin 12})
-
 (def general-styles
   {:font-family ["Open Sans" "Helvetica" "sans-serif"]
    :font-size "95%"
@@ -31,6 +29,12 @@
 
 (def text-field {:margin 5 :display "inline-block"})
 
+(def select-field text-field)
+
+(def date-picker text-field)
+
 (def tabs-header {:cursor "pointer"})
 
 (def tab-header-link {:text-decoration "none"})
+
+(def button (merge text-field {:margin 12}))

--- a/va-admin-ui/src/oph/va/admin_ui/theme.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/theme.cljs
@@ -29,7 +29,7 @@
 
 (def notice {:padding "10px"})
 
-(def text-field {:margin-right 15 :display "inline-block"})
+(def text-field {:margin 5 :display "inline-block"})
 
 (def tabs-header {:cursor "pointer"})
 

--- a/va-admin-ui/src/oph/va/admin_ui/theme.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/theme.cljs
@@ -30,3 +30,7 @@
 (def notice {:padding "10px"})
 
 (def text-field {:margin-right 15 :display "inline-block"})
+
+(def tabs-header {:cursor "pointer"})
+
+(def tab-header-link {:text-decoration "none"})

--- a/va-admin-ui/src/oph/va/admin_ui/va_code_values/code_values_core.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/va_code_values/code_values_core.cljs
@@ -5,6 +5,7 @@
    [reagent.core :as r]
    [cljsjs.material-ui]
    [cljs-react-material-ui.core :refer [color]]
+   [oph.va.admin-ui.components.ui :as va-ui]
    [cljs-react-material-ui.reagent :as ui]
    [cljs-react-material-ui.icons :as ic]
    [oph.va.admin-ui.theme :as theme]
@@ -34,23 +35,23 @@
   (let [v (r/atom {})]
     (fn [on-change]
       [:div {:style {:max-width 1000}}
-       [:div
-        [ui/text-field
+       [:div {:style {:display "inline"}}
+        [va-ui/text-field
          {:floating-label-text "Vuosi"
           :value (or (:year @v) "")
           :on-change #(swap! v assoc :year (.-value (.-target %)))
           :style (assoc theme/text-field :width 50)}]
-        [ui/text-field
+        [va-ui/text-field
          {:floating-label-text "Koodi"
           :value (or (:code @v) "")
           :on-change #(swap! v assoc :code (.-value (.-target %)))
           :style (assoc theme/text-field :width 100)}]
-        [ui/text-field
+        [va-ui/text-field
          {:floating-label-text "Nimi"
           :value (or (:name @v) "")
           :on-change #(swap! v assoc :name (.-value (.-target %)))
-          :style theme/text-field}]]
-       [ui/raised-button
+          :style (assoc theme/text-field :width 350)}]]
+       [va-ui/raised-button
         {:label "Lisää"
          :primary true
          :disabled (or (not= (count @v) 3)
@@ -68,13 +69,10 @@
 
 (defn home-page []
   [:div
-   [ui/tabs
-    [ui/tab {:label "Toimintayksikkö"}
-     (render-tab :operational-unit)]
-    [ui/tab {:label "Projekti"}
-     (render-tab :project)]
-    [ui/tab {:label "Toiminto"}
-     (render-tab :operation)]]])
+   [va-ui/tabs
+    [{:label "Toimintayksikkö" :content (render-tab :operational-unit)}
+     {:label "Projekti" :content (render-tab :project)}
+     {:label "Toiminto" :content (render-tab :operation)}]]])
 
 (defn init! []
   (go

--- a/va-admin-ui/src/oph/va/admin_ui/va_code_values/code_values_core.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/va_code_values/code_values_core.cljs
@@ -39,8 +39,10 @@
         [va-ui/text-field
          {:floating-label-text "Vuosi"
           :value (or (:year @v) "")
+          :type "number"
+          :max-length 4
           :on-change #(swap! v assoc :year (.-value (.-target %)))
-          :style (assoc theme/text-field :width 50)}]
+          :style (assoc theme/text-field :width 75)}]
         [va-ui/text-field
          {:floating-label-text "Koodi"
           :value (or (:code @v) "")

--- a/va-virkailija/resources/public/admin-ui/index.html
+++ b/va-virkailija/resources/public/admin-ui/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="/admin-ui/css/site.css" rel="stylesheet" type="text/css">
+    <link href="/admin-ui/css/oph-styles-min.css" rel="stylesheet" type="text/css">
     <link href="/admin-ui/images/favicon.ico" rel="icon" sizes="32x32 64x64"
       type="image/vnd.microsoft.icon">
   </head>


### PR DESCRIPTION
OPH:n tyylit komponenteille.

Kaikkia komponentteja ei vielä tueta ja esim. datepicker tulee material ui:lta.

Tässä käytetään oph:n style guiden github repoa. Se ladataan ja buildataan (vain make build / lein package).