### PR TITLE
Va3 226 move sending to backend

### DIFF
--- a/va-admin-ui/src/oph/va/admin_ui/connection.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/connection.cljs
@@ -89,6 +89,10 @@
   (http/post (format "/%s/payment-batches/" api-path)
              {:json-params data :with-credentials? true}))
 
+(defn create-batch-payments [id]
+  (http/post (format "/%s/payment-batches/%d/payments/" api-path id)
+             {:with-credentials? true}))
+
 (defn get-va-code-values-by-type []
   (let [c (chan)]
     (go

--- a/va-virkailija/resources/sql/virkailija/applications/get-application-with-evaluation-and-answers.sql
+++ b/va-virkailija/resources/sql/virkailija/applications/get-application-with-evaluation-and-answers.sql
@@ -15,6 +15,7 @@ WHERE
   h.id = :application_id
   AND h.status != 'cancelled'
   AND h.status != 'new'
+  AND h.status != 'draft'
   AND h.version_closed IS NULL
   AND h.hakemus_type = 'hakemus'
 ORDER BY

--- a/va-virkailija/resources/sql/virkailija/applications/get-application.sql
+++ b/va-virkailija/resources/sql/virkailija/applications/get-application.sql
@@ -11,6 +11,7 @@ WHERE
   h.id = :application_id
   AND h.status != 'cancelled'
   AND h.status != 'new'
+  AND h.status != 'draft'
   AND h.version_closed IS NULL
   AND h.hakemus_type = 'hakemus'
 ORDER BY

--- a/va-virkailija/resources/sql/virkailija/grants/get-accepted-grant-applications-with-evaluation.sql
+++ b/va-virkailija/resources/sql/virkailija/grants/get-accepted-grant-applications-with-evaluation.sql
@@ -13,6 +13,7 @@ JOIN
     ON (h.id = a.hakemus_id)
 WHERE
   h.avustushaku = :grant_id
+  AND h.status != 'cancelled'
   AND h.status != 'draft'
   AND h.status != 'new'
   AND a.status = 'accepted'

--- a/va-virkailija/resources/sql/virkailija/grants/get-grant-applications.sql
+++ b/va-virkailija/resources/sql/virkailija/grants/get-grant-applications.sql
@@ -10,6 +10,7 @@ WHERE
   h.avustushaku = :grant_id
   AND h.status != 'cancelled'
   AND h.status != 'new'
+  AND h.status != 'draft'
   AND h.version_closed IS NULL
   AND h.hakemus_type = 'hakemus'
 ORDER BY

--- a/va-virkailija/resources/sql/virkailija/grants/get-unpaid-applications.sql
+++ b/va-virkailija/resources/sql/virkailija/grants/get-unpaid-applications.sql
@@ -1,0 +1,23 @@
+SELECT
+  h.id, h.created_at, h.version, h.budget_total, h.budget_oph_share,
+  h.organization_name, h.project_name, h.register_number, h.language,
+  h.avustushaku AS grant_id, s.answers->'value' AS answers
+FROM
+  hakija.hakemukset h
+JOIN
+  hakija.form_submissions s
+    ON (h.form_submission_id = s.id AND h.form_submission_version = s.version)
+LEFT JOIN
+  virkailija.payments p
+    ON (p.application_id = h.id AND p.application_version = h.version
+        AND p.version_closed IS NULL AND p.deleted IS NULL)
+WHERE
+  h.avustushaku = :grant_id
+  AND h.status != 'cancelled'
+  AND h.status != 'new'
+  AND h.status != 'draft'
+  AND h.version_closed IS NULL
+  AND h.hakemus_type = 'hakemus'
+  AND (p.state < 2 OR p.state IS NULL)
+ORDER BY
+  upper(h.organization_name), upper(h.project_name);

--- a/va-virkailija/resources/sql/virkailija/payment_batches/get-batch.sql
+++ b/va-virkailija/resources/sql/virkailija/payment_batches/get-batch.sql
@@ -1,0 +1,8 @@
+SELECT
+  id, created_at, batch_number, document_type, invoice_date, due_date,
+  receipt_date, transaction_account, currency, partner, inspector_email,
+  acceptor_email, grant_id
+FROM
+  virkailija.payment_batches
+WHERE
+  id = :batch_id;

--- a/va-virkailija/src/clojure/oph/va/virkailija/db/queries.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/db/queries.clj
@@ -37,6 +37,8 @@
   "sql/virkailija/grants/delete-grant-payments.sql")
 (defquery get-grant-payments-info
   "sql/virkailija/grants/get-grant-payments-info.sql")
+(defquery get-unpaid-applications
+  "sql/virkailija/grants/get-unpaid-applications.sql")
 
 (defquery get-payment "sql/virkailija/payments/get-payment.sql")
 (defquery get-payment-version "sql/virkailija/payments/get-payment-version.sql")
@@ -49,6 +51,7 @@
 
 (defquery find-batch "sql/virkailija/payment_batches/find-batch.sql")
 (defquery create-batch "sql/virkailija/payment_batches/create-batch.sql")
+(defquery get-batch "sql/virkailija/payment_batches/get-batch.sql")
 
 (defquery get-application "sql/virkailija/applications/get-application.sql")
 (defquery get-application-with-evaluation-and-answers

--- a/va-virkailija/src/clojure/oph/va/virkailija/grant_data.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/grant_data.clj
@@ -30,3 +30,8 @@
   (mapv convert-to-dash-keys
         (exec :form-db virkailija-queries/get-grant-applications
               {:grant_id grant-id})))
+
+(defn get-unpaid-applications [grant-id]
+  (mapv convert-to-dash-keys
+        (exec :form-db virkailija-queries/get-unpaid-applications
+              {:grant_id grant-id})))

--- a/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_data.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_data.clj
@@ -19,3 +19,9 @@
        first
        convert-to-dash-keys
        convert-timestamps-from-sql))
+
+(defn get-batch [id]
+  (-> (exec :form-db queries/get-batch {:batch_id id})
+      first
+      convert-to-dash-keys
+      convert-timestamps-from-sql))

--- a/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
@@ -90,7 +90,7 @@
                 (if (:success result)
                   (payments-data/update-payment
                     (assoc payment :state 2 :filename filename) identity)
-                  (a/>! c (:error result))))))
+                  (a/>! c (:error-type result))))))
           (a/close! c))
         (let [error-count
               (loop [error-count 0]
@@ -105,5 +105,4 @@
   "payment batches routes"
   (find-payment-batch)
   (create-payment-batch)
-  (create-payments)
-  (create-dsa))
+  (create-payments))

--- a/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
@@ -1,9 +1,17 @@
 (ns oph.va.virkailija.payment-batches-routes
-  (:require [compojure.api.sweet :as compojure-api]
-            [ring.util.http-response :refer [ok no-content]]
+  (:require [clojure.core.async :as a]
+            [compojure.api.sweet :as compojure-api]
+            [ring.util.http-response :refer [ok no-content request-timeout]]
             [oph.va.virkailija.payment-batches-data :as data]
-            [oph.va.virkailija.schema :as schema])
+            [oph.va.virkailija.grant-data :as grant-data]
+            [oph.va.virkailija.application-data :as application-data]
+            [oph.va.virkailija.payments-data :as payments-data]
+            [oph.va.virkailija.rondo-service :as rondo-service]
+            [oph.va.virkailija.schema :as schema]
+            [oph.va.virkailija.authentication :as authentication])
   (:import (java.time LocalDate)))
+
+(def timeout-limit 10000)
 
 (defn- find-payment-batch []
   (compojure-api/GET
@@ -28,8 +36,72 @@
           "Payment batch already found for given grant and current date.")))
     (ok (data/create-batch batch-values))))
 
+(defn- create-payments []
+  (compojure-api/POST
+    "/:id/payments/" [id :as request]
+    :path-params [id :- Long]
+    :return schema/PaymentsCreateResult
+    :summary "Create new payments for unpaid applications of grant. Payments
+              will be sent to Rondo and stored to database."
+    (let [identity (authentication/get-request-identity request)
+          batch (data/get-batch id)
+          grant (grant-data/get-grant (:grant-id batch))]
+      (when (get-in grant [:content :multiplemaksuera])
+        (throw (Exception. "Multiple payment batches is not supported.")))
+
+      (let [applications
+            (grant-data/get-unpaid-applications (:id grant))
+            c (a/chan)]
+        (a/go
+          (doseq [application applications]
+            (let [payment-values {:application-id (:id application)
+                                  :application-version (:version application)
+                                  :state 0
+                                  :batch-id (:id batch)}
+                  payment
+                  (or (application-data/get-application-payment
+                        (:id application))
+                      (payments-data/create-payment payment-values identity))
+                  filename (format "payment-%d-%d.xml"
+                                   (:id payment)
+                                   (System/currentTimeMillis))
+                  ac (a/chan)]
+              (a/go
+                (try
+                  (rondo-service/send-to-rondo!
+                    {:payment (payments-data/get-payment (:id payment))
+                     :application application
+                     :grant grant
+                     :filename filename})
+                  (a/>! ac {:success true})
+                  (catch Exception e
+                    (a/>! ac {:success false :exception e}))))
+              (a/alt!
+                ac ([v]
+                    (prn v)
+                    (if (:success v)
+                      (payments-data/update-payment
+                        (assoc payment :state 2 :filename filename)
+                        identity)
+                      (do
+                        (a/>! c v)
+                        (throw (:exception v))))
+                    )
+                (a/timeout timeout-limit)
+                ([_]
+                 (a/>! c {:success false :error :timeout})
+                 (throw "SSH timeout")))))
+          (a/>! c {:success true}))
+        (let [result (a/<!! c)]
+          (cond
+            (:success result) (ok {:success true})
+            (= (:error result) :timeout) (request-timeout {:success false})
+            :else (throw (:exception result))))))))
+
 (compojure-api/defroutes
   routes
   "payment batches routes"
   (find-payment-batch)
-  (create-payment-batch))
+  (create-payment-batch)
+  (create-payments)
+  (create-dsa))

--- a/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
@@ -78,7 +78,6 @@
                     (a/>! ac {:success false :exception e}))))
               (a/alt!
                 ac ([v]
-                    (prn v)
                     (if (:success v)
                       (payments-data/update-payment
                         (assoc payment :state 2 :filename filename)

--- a/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/payment_batches_routes.clj
@@ -9,7 +9,8 @@
             [oph.va.virkailija.payments-data :as payments-data]
             [oph.va.virkailija.rondo-service :as rondo-service]
             [oph.va.virkailija.schema :as schema]
-            [oph.va.virkailija.authentication :as authentication])
+            [oph.va.virkailija.authentication :as authentication]
+            [oph.va.virkailija.utils :refer [with-timeout]])
   (:import (java.time LocalDate)))
 
 (def timeout-limit 10000)
@@ -42,14 +43,6 @@
    :application-version (:version application)
    :state 0
    :batch-id (:id batch)})
-
-(defn with-timeout [f t tv]
-  (let [c (a/chan)]
-    (a/go
-      (a/>! c (f)))
-    (a/alt!!
-      c ([v] v)
-      (a/timeout t) ([_] tv))))
 
 (defn- create-payments []
   (compojure-api/POST

--- a/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/schema.clj
@@ -347,3 +347,7 @@
    :acceptor-email s/Str
    :grant-id s/Int
    :document-id s/Str})
+
+(s/defschema PaymentsCreateResult
+  "Payment create result"
+  {:success s/Bool})

--- a/va-virkailija/src/clojure/oph/va/virkailija/utils.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/utils.clj
@@ -1,5 +1,6 @@
 (ns oph.va.virkailija.utils
-  (:require [clojure.set :refer [rename-keys]]))
+  (:require [clojure.set :refer [rename-keys]]
+            [clojure.core.async :refer [go timeout chan >! alt!!]]))
 
 (defn- key-contains? [k v]
   (.contains (name k) v))
@@ -40,3 +41,16 @@
   (if (contains? m k)
     (update m k f)
     m))
+
+(defn with-timeout
+  "Function for performing task with timeout protection.
+  Given function (f) will be called.
+  If timeout (t) happens before given function finishes timeout value (tv)
+  will be returned."
+  [f t tv & a]
+  (let [c (chan)]
+    (go
+      (>! c (f)))
+    (alt!!
+      c ([v] v)
+      (timeout t) ([_] tv))))


### PR DESCRIPTION
Maksatukset luodaan ja lähetetään nyt backendissa.

Tämä nopeuttaa paljon, koska toiminto menee nyt yhdellä kutsulla.

Mahdollista yksittäisen maksatuksen virhettä ei tässä tapauksessa frontille tule, mutta sekin on mahdollista tehdä, jos näin tarvitsee.