### PR TITLE
Va3 239 fix failing payments email

### DIFF
--- a/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
+++ b/va-admin-ui/src/oph/va/admin_ui/payments/payments_core.cljs
@@ -89,7 +89,7 @@
       (put! dialog-chan 1)
       (let [result (<! (connection/create-batch-payments (:batch-id values)))]
         (put! dialog-chan 2)
-        (if (:success result)
+        (if (and (:success result) (get-in result [:body :success]))
           (let [email-result
                 (<!
                   (connection/send-payments-email

--- a/va-virkailija/resources/sql/virkailija/grants/get-grant-payments-info.sql
+++ b/va-virkailija/resources/sql/virkailija/grants/get-grant-payments-info.sql
@@ -7,7 +7,7 @@ JOIN
   virkailija.payments p
   ON
     (p.application_id = h.id AND p.version_closed IS NULL AND
-     p.deleted IS NULL AND p.batch_id = :batch_id)
+     p.deleted IS NULL AND p.batch_id = :batch_id AND p.state = 2)
 JOIN
   virkailija.arviot a ON a.hakemus_id = p.application_id
 WHERE


### PR DESCRIPTION
Korjaus kahteen maksatuksen prossessissa esiintyvään ongelmaan:

- Sähköposti lähetettiin, vaikka jokin maksatuksen lähetys epäonnistui
- Sähköpostiin otettiin mukaan myös maksatuksia, jotka eivät olleet lähetetty Rondoon asti