### PR TITLE
Va3 301 move should pay button to seuranta tab

### DIFF
--- a/va-virkailija/web/va/TopBar.jsx
+++ b/va-virkailija/web/va/TopBar.jsx
@@ -33,8 +33,7 @@ class TopBarTabs extends React.Component {
   }
 
   render() {
-    const {activeTab, disabled, config, userInfo,
-           state, selectedHakuId} = this.props
+    const {activeTab, disabled, config, userInfo, selectedHakuId} = this.props
     const isAdmin = userInfo.privileges.indexOf("va-admin") > -1
     return (
       <div id="tabs">

--- a/va-virkailija/web/va/hakemus-details/HakemusArviointi.jsx
+++ b/va-virkailija/web/va/hakemus-details/HakemusArviointi.jsx
@@ -40,7 +40,6 @@ export default class HakemusArviointi extends Component {
     const comments = hakemus.comments
     const loadingComments = this.props.loadingComments
     const showOthersScores = this.props.showOthersScores
-    const showShouldPayComments = true
 
     return (
      <div id="arviointi-tab">
@@ -53,8 +52,6 @@ export default class HakemusArviointi extends Component {
        <HakemusComments controller={controller} hakemus={hakemus} comments={comments} loadingComments={loadingComments} allowHakemusCommenting={allowHakemusCommenting}/>
        <SetArviointiStatus controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges} />
        <Perustelut controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges} />
-       <ShouldPay controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges}/>
-       <ShouldPayComments showField={showShouldPayComments} controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges}/>
        <ChangeRequest controller={controller} hakemus={hakemus} avustushaku={avustushaku} allowEditing={allowHakemusStateChanges} />
        <SummaryComment controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges} />
        <HakemusBudgetEditing avustushaku={avustushaku} hakuData={hakuData} translations={translations} controller={controller} hakemus={hakemus} allowEditing={allowHakemusStateChanges} />

--- a/va-virkailija/web/va/hakemus-details/HakemusArviointi.jsx
+++ b/va-virkailija/web/va/hakemus-details/HakemusArviointi.jsx
@@ -17,8 +17,6 @@ import AcademySize from './AcademySize.jsx'
 import Perustelut from './Perustelut.jsx'
 import PresenterComment from './PresenterComment.jsx'
 import EditStatus from './EditStatus.jsx'
-import ShouldPay from './ShouldPay.jsx'
-import ShouldPayComments from './ShouldPayComments.jsx'
 import ApplicationPayments from './ApplicationPayments.jsx'
 
 import '../style/admin.less'

--- a/va-virkailija/web/va/hakemus-details/HakemusDetails.jsx
+++ b/va-virkailija/web/va/hakemus-details/HakemusDetails.jsx
@@ -71,7 +71,7 @@ export default class HakemusDetails extends Component {
                            selvitysType="loppuselvitys"
                            environment={environment}/>
         case 'seuranta':
-          return <Seuranta controller={controller} hakemus={hakemus} avustushaku={avustushaku} hakuData={hakuData} translations={translations}/>
+          return <Seuranta controller={controller} hakemus={hakemus} avustushaku={avustushaku} hakuData={hakuData} translations={translations} selectedHakemusAccessControl={selectedHakemusAccessControl}/>
         default:
           throw new Error("Bad subTab selection '" + tabName + "'")
       }

--- a/va-virkailija/web/va/hakemus-details/Seuranta.jsx
+++ b/va-virkailija/web/va/hakemus-details/Seuranta.jsx
@@ -3,13 +3,18 @@ import PresenterComment from './PresenterComment.jsx'
 import SeurantaLiitteet from './SeurantaLiitteet.jsx'
 import SeurantaTags from './SeurantaTags.jsx'
 import SeurantaBudgetEditing from '../seurantabudgetedit/SeurantaBudgetEditing.jsx'
+import ShouldPay from './ShouldPay.jsx'
+import ShouldPayComments from './ShouldPayComments.jsx'
 
 export default class Seuranta extends React.Component {
   render() {
     const {controller, hakemus, avustushaku, translations, hakuData} = this.props
+    const allowEditing = this.props.selectedHakemusAccessControl.allowHakemusStateChanges
     return (
       <div className="seuranta">
         <PresenterComment controller={controller} hakemus={hakemus}/>
+        <ShouldPay controller={controller} hakemus={hakemus} allowEditing={allowEditing}/>
+        <ShouldPayComments controller={controller} hakemus={hakemus} allowEditing={allowEditing}/>
         <div className="seuranta-section">
           <SeurantaBudgetEditing avustushaku={avustushaku} hakuData={hakuData} translations={translations} controller={controller} hakemus={hakemus}/>
         </div>

--- a/va-virkailija/web/va/hakemus-details/Seuranta.jsx
+++ b/va-virkailija/web/va/hakemus-details/Seuranta.jsx
@@ -12,10 +12,10 @@ export default class Seuranta extends React.Component {
     const allowEditing = this.props.selectedHakemusAccessControl.allowHakemusStateChanges
     return (
       <div className="seuranta">
-        <PresenterComment controller={controller} hakemus={hakemus}/>
         <ShouldPay controller={controller} hakemus={hakemus} allowEditing={allowEditing}/>
         <ShouldPayComments controller={controller} hakemus={hakemus} allowEditing={allowEditing}/>
         <div className="seuranta-section">
+        <PresenterComment controller={controller} hakemus={hakemus}/>
           <SeurantaBudgetEditing avustushaku={avustushaku} hakuData={hakuData} translations={translations} controller={controller} hakemus={hakemus}/>
         </div>
         <div className="seuranta-section">


### PR DESCRIPTION
Eli siirretiin seuranta-välilehdelle se maksetaannappi + kommenttiloota, pois tuolta arviointi-välilehdeltä ja siivoiltiin turhat koodit arvioinnista.