### PR TITLE
Va3 376 refuse grant after decision

### DIFF
--- a/va-hakija/resources/sql/spec/create-test-application-token.sql
+++ b/va-hakija/resources/sql/spec/create-test-application-token.sql
@@ -1,0 +1,7 @@
+INSERT
+  INTO hakija.application_tokens
+    (application_id, token)
+  VALUES
+    (:application_id, :token)
+RETURNING
+  token

--- a/va-hakija/src/oph/va/hakija/db.clj
+++ b/va-hakija/src/oph/va/hakija/db.clj
@@ -213,15 +213,15 @@
      :size (:file_size result)}))
 
 (defn create-application-token [application-id]
-  (let [existing-token
-        (first (exec :form-db queries/find-application-token
-                     {:application_id application-id}))]
+ (let [existing-token
+       (first (exec :form-db queries/find-application-token
+                    {:application_id application-id}))]
 
-    (if (some? existing-token)
-      {:token (:token existing-token)}
-      (first
-        (exec :form-db queries/create-application-token
-              {:application_id application-id :token (generate-hash-id)})))))
+   (if (some? existing-token)
+     {:token (:token existing-token)}
+     (first
+       (exec :form-db queries/create-application-token
+             {:application_id application-id :token (generate-hash-id)})))))
 
 (defn valid-token? [token application-id]
   (and

--- a/va-hakija/src/oph/va/hakija/db/queries.clj
+++ b/va-hakija/src/oph/va/hakija/db/queries.clj
@@ -16,7 +16,7 @@
 (defquery update-valiselvitys-status<! "sql/common/hakija/hakemus/update-valiselvitys-status.sql")
 (defquery close-existing-hakemus! "sql/common/hakija/hakemus/close-existing.sql")
 (defquery set-refused "sql/hakemus/set-refused.sql")
-(defquery create-application-token "sql/hakemus/create-application-token.sql")
+(defquery create-test-application-token "sql/spec/create-test-application-token.sql")
 (defquery get-application-token "sql/hakemus/get-application-token.sql")
 (defquery find-application-token "sql/hakemus/find-application-token.sql")
 (defquery revoke-application-token! "sql/hakemus/revoke-token.sql")

--- a/va-hakija/src/oph/va/hakija/email.clj
+++ b/va-hakija/src/oph/va/hakija/email.clj
@@ -83,9 +83,7 @@
           (email/refuse-url avustushaku-id user-key
                       lang (create-application-token user-key)))
         user-message {:operation :send
-                      :type (if refuse-enabled?
-                              :hakemus-submitted-refuse
-                              :hakemus-submitted)
+                      :type  :hakemus-submitted
                       :lang lang
                       :from (-> email/smtp-config :from lang)
                       :sender (-> email/smtp-config :sender)

--- a/va-hakija/src/oph/va/hakija/email.clj
+++ b/va-hakija/src/oph/va/hakija/email.clj
@@ -5,8 +5,7 @@
             [clojure.tools.trace :refer [trace]]
             [clojure.tools.logging :as log]
             [clostache.parser :refer [render]]
-            [oph.soresu.common.config :refer [config]]
-            [oph.va.hakija.application-data :refer [create-application-token]]))
+            [oph.soresu.common.config :refer [config]]))
 
 (def mail-titles
   {:new-hakemus {:fi "Linkki organisaationne avustushakemukseen"
@@ -76,12 +75,6 @@
         end-date-string (datetime/date-string end-date)
         end-time-string (datetime/time-string end-date)
         url (email/generate-url avustushaku-id lang lang-str user-key true)
-        refuse-enabled?
-        (get-in config [:application-change :refuse-enabled?] false)
-        refuse-url
-        (when refuse-enabled?
-          (email/refuse-url avustushaku-id user-key
-                      lang (create-application-token user-key)))
         user-message {:operation :send
                       :type  :hakemus-submitted
                       :lang lang
@@ -94,8 +87,6 @@
                       :start-time start-time-string
                       :end-date end-date-string
                       :end-time end-time-string
-                      :url url
-                      :refuse-url refuse-url}]
+                      :url url}]
     (log/info "Urls would be: " url)
-    (when refuse-enabled? (log/info "Refuse url: " refuse-url))
     (>!! email/mail-chan user-message)))

--- a/va-hakija/src/oph/va/hakija/routes.clj
+++ b/va-hakija/src/oph/va/hakija/routes.clj
@@ -1,5 +1,6 @@
 (ns oph.va.hakija.routes
-  (:use [clojure.tools.trace :only [trace]])
+  (:use [clojure.tools.trace :only [trace]]
+        [oph.soresu.common.db])
   (:require [clojure.tools.logging :as log]
             [ring.util.http-response :refer :all]
             [ring.util.response :as resp]
@@ -20,7 +21,8 @@
             [oph.va.hakija.db :as hakija-db]
             [oph.va.hakija.schema :refer :all]
             [oph.va.hakija.handlers :refer :all]
-            [oph.common.organisation-service :as org]))
+            [oph.common.organisation-service :as org]
+            [oph.va.hakija.db.queries :as queries]))
 
 (defn- on-healthcheck []
   (if (hakija-db/health-check)
@@ -61,7 +63,7 @@
            (compojure-api/describe ApplicationTokenData
                                    "New application token for tests")]
     :return ApplicationToken
-    (ok (hakija-db/create-application-token (:application-id token-data)))))
+    (ok (first (exec :form-db queries/create-test-application-token {:application_id (:application-id token-data) :token (generate-hash-id)})))))
 
 (defn- avustushaku-ok-response [avustushaku]
   (ok (va-routes/avustushaku-response-content avustushaku)))

--- a/va-virkailija/resources/sql/hakija/hakemus/create-application-token.sql
+++ b/va-virkailija/resources/sql/hakija/hakemus/create-application-token.sql
@@ -1,0 +1,7 @@
+INSERT
+  INTO hakija.application_tokens
+    (application_id, token)
+  VALUES
+    (:application_id, :token)
+RETURNING
+  token

--- a/va-virkailija/spec/oph/va/virkailija/application_data_spec.clj
+++ b/va-virkailija/spec/oph/va/virkailija/application_data_spec.clj
@@ -46,6 +46,7 @@
         (should (empty? (application-data/revoke-application-tokens
                           (:id application)))))))
 
+
 (describe
   "Get applications"
 
@@ -137,5 +138,6 @@
                       (assoc payment :state 2 :filename "file.xml") user)]
         (should= 0 (count (application-data/get-application-unsent-payments
                             (:id application)))))))
+
 
 (run-specs)

--- a/va-virkailija/src/clojure/oph/va/hakija/api/queries.clj
+++ b/va-virkailija/src/clojure/oph/va/hakija/api/queries.clj
@@ -52,6 +52,7 @@
 (defquery lock-hakemus "sql/common/hakija/hakemus/lock.sql")
 (defquery close-existing-hakemus! "sql/common/hakija/hakemus/close-existing.sql")
 (defquery find-matching-hakemukset-by-organization-name "sql/hakija/hakemus/find-matching-by-organization-name.sql")
+(defquery create-application-token "sql/hakija/hakemus/create-application-token.sql")
 (defquery revoke-application-tokens
   "sql/hakija/hakemus/revoke-application-tokens.sql")
 (defquery get-application "sql/hakija/hakemus/get-application.sql")

--- a/va-virkailija/src/clojure/oph/va/virkailija/application_data.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/application_data.clj
@@ -1,5 +1,6 @@
 (ns oph.va.virkailija.application-data
   (:require [oph.soresu.common.db :refer [exec]]
+            [oph.va.virkailija.db :as va-db]
             [oph.va.virkailija.utils :refer [convert-to-dash-keys]]
             [clj-time.core :as t]
             [oph.va.virkailija.db.queries :as virkailija-queries]
@@ -48,6 +49,9 @@
              hakija-queries/find-applications
              {:search_term (str "%" (clojure.string/lower-case search-term) "%")})))
 
+
+ (defn create-application-token [application-id]
+     (:token (va-db/create-application-token application-id)))
 
 
 (defn get-application-token [application-id]

--- a/va-virkailija/src/clojure/oph/va/virkailija/db.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/db.clj
@@ -4,6 +4,7 @@
         [clojure.tools.trace :only [trace]])
   (:require [oph.soresu.form.formutil :as formutil]
             [oph.va.virkailija.db.queries :as queries]
+            [oph.va.hakija.api.queries :as hakija-queries]
             [oph.va.hakija.api :as hakija-api]
             [clojure.string :as string]
             [clojure.java.jdbc :as jdbc]
@@ -331,3 +332,14 @@
                                       "order by first_name, surname, email"])
                         escaped-terms-for-like-exprs)
                   {:row-fn db->va-user}))))
+
+(defn create-application-token [application-id]
+  (let [existing-token
+        (first (exec :form-db hakija-queries/get-application-token
+                       {:application_id application-id}))]
+
+      (if (some? existing-token)
+        {:token (:token existing-token)}
+        (first
+          (exec :form-db hakija-queries/create-application-token
+                {:application_id application-id :token (generate-hash-id)})))))

--- a/va-virkailija/src/clojure/oph/va/virkailija/paatos.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/paatos.clj
@@ -14,7 +14,7 @@
     [clojure.string :as str]
     [oph.va.virkailija.decision :as decision]
     [oph.soresu.common.config :refer [config]]
-    [oph.va.virkailija.application-data :refer [get-application-token]]
+    [oph.va.virkailija.application-data :refer [get-application-token create-application-token]]
     [oph.va.virkailija.payments-data :as payments-data]
     [oph.va.virkailija.authentication :as authentication]))
 
@@ -42,7 +42,7 @@
         decision (decision/paatos-html hakemus-id)
         arvio (virkailija-db/get-arvio hakemus-id)
         token (when (get-in config [:application-change :refuse-enabled?])
-                (get-application-token (:id hakemus)))]
+                  (create-application-token (:id hakemus)))]
     (log/info "Sending paatos email for hakemus" hakemus-id " to " emails)
     (if (and (some? token) (not= (:status arvio) "rejected"))
       (email/send-paatos-refuse!


### PR DESCRIPTION
Elikäs, siirretty tuo kieltäytymislinkki sinne päätösmeiliin, pois submission-meilistä ja siinä samalla siirretty tokenin luominen virkailijaan. Lisätty kuitenkin tuo create-test-token.sql, jotta testeissä voidaan luoda token ja routesin testi routea käyttää. 