### PR TITLE
Va3 442 fix requires

### DIFF
--- a/soresu-form/src/oph/soresu/form/formhandler.clj
+++ b/soresu-form/src/oph/soresu/form/formhandler.clj
@@ -10,11 +10,11 @@
       node))
 
 (defn- resolve-field-type [koodisto-field]
-  (or (-> koodisto-field :params :inputType)
+  (or (get-in koodisto-field [:params :inputType])
       default-koodisto-field-type))
 
 (defn- add-koodisto-options [db-key koodisto-field-node]
-  (let [koodisto-params (-> koodisto-field-node :params :koodisto)
+  (let [koodisto-params (get-in koodisto-field-node [:params :koodisto])
         koodisto-uri (:uri koodisto-params)
         version (:version koodisto-params)]
     (assoc

--- a/soresu-form/src/oph/soresu/form/formhandler.clj
+++ b/soresu-form/src/oph/soresu/form/formhandler.clj
@@ -1,6 +1,6 @@
 (ns oph.soresu.form.formhandler
-  (require [oph.soresu.form.formutil :as formutil]
-           [oph.soresu.common.koodisto :as koodisto]))
+  (:require [oph.soresu.form.formutil :as formutil]
+            [oph.soresu.common.koodisto :as koodisto]))
 
 (def default-koodisto-field-type "dropdown")
 

--- a/soresu-form/src/oph/soresu/form/formhandler.clj
+++ b/soresu-form/src/oph/soresu/form/formhandler.clj
@@ -17,13 +17,19 @@
   (let [koodisto-params (-> koodisto-field-node :params :koodisto)
         koodisto-uri (:uri koodisto-params)
         version (:version koodisto-params)]
-    (assoc koodisto-field-node :options (:content (koodisto/get-cached-koodi-options db-key koodisto-uri version)))))
+    (assoc
+      koodisto-field-node :options
+      (:content
+       (koodisto/get-cached-koodi-options db-key koodisto-uri version)))))
 
 (defn- set-field-type-from-params [koodisto-field-node]
-  (assoc koodisto-field-node :fieldType (resolve-field-type koodisto-field-node)))
+  (assoc
+    koodisto-field-node :fieldType
+    (resolve-field-type koodisto-field-node)))
 
 (defn- transform-koodisto-fields [node-operation form]
-  (formutil/transform-form-content form #(process-koodisto-field % node-operation)))
+  (formutil/transform-form-content
+    form #(process-koodisto-field % node-operation)))
 
 (defn add-koodisto-values [db-key form]
   (->> form

--- a/va-virkailija/src/clojure/oph/va/virkailija/lkp_templates.clj
+++ b/va-virkailija/src/clojure/oph/va/virkailija/lkp_templates.clj
@@ -1,5 +1,5 @@
 (ns oph.va.virkailija.lkp-templates
-  (require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]))
 
 (def built-in-templates ["lkp-templates/ownership_type.edn"
                          "lkp-templates/radio_button_0.edn"])


### PR DESCRIPTION
Parista requiresta puuttui kaksoispiste. Tuo ei mene enää läpi tulevissa Clojuren versioissa.

Samalla pari pientä refaktorointia.