### PR TITLE
Don't stop the email sending background job when one invalid email is encountered

### DIFF
--- a/va-common/src/oph/common/email.clj
+++ b/va-common/src/oph/common/email.clj
@@ -121,8 +121,11 @@
             stop? (case (:operation msg)
                     :stop true
                     :send (do
-                            (send-msg! msg
+                            (try
+                              (send-msg! msg
                                        (partial render (get-in mail-templates [(:type msg) (:lang msg)])))
+                            (catch Exception e
+                              (log/error e "Failed to send email")))
                             false))]
         (if (not stop?)
           (recur))))


### PR DESCRIPTION
If (when) email sending throws Exception, all subsequent emails are left unprocessed as the background job dies.

Added try-catch to keep this from happening